### PR TITLE
feat: Add Star Citizen glossary and metadata (zh-CN)

### DIFF
--- a/glossaries/starcitizen.csv
+++ b/glossaries/starcitizen.csv
@@ -1,0 +1,285 @@
+source,target,tgt_lng
+星际公民,Star Citizen,zh-CN
+Aegis,圣盾,zh-CN
+铁砧,Anvil,zh-CN
+南船座,Argo,zh-CN
+联合外域,C.O.,zh-CN
+Consolidated Outlands,联合外域,zh-CN
+Crusader,十字军,zh-CN
+Drake,德雷克,zh-CN
+MISC,武藏,zh-CN
+Mirai,未来,zh-CN
+Mustang,野马,zh-CN
+Kruger,克鲁格,zh-CN
+Origin,起源,zh-CN
+Greycat,灰猫,zh-CN
+Tumbril,盾博尔,zh-CN
+Aopoa,奥波亚,zh-CN
+Banu,巴努,zh-CN
+Esperia,埃斯佩里亚,zh-CN
+Gatac,盖塔克,zh-CN
+Vanduul,剜度,zh-CN
+Advocacy,督导局,zh-CN
+Avenger Stalker,复仇者 追猎,zh-CN
+Avenger Titan,复仇者 泰坦,zh-CN
+Avenger Titan Renegade,复仇者 泰坦变节者,zh-CN
+Avenger Warlock,复仇者 术士,zh-CN
+Eclipse,日蚀,zh-CN
+Gladius,短剑,zh-CN
+Gladius Dunlevy,短剑 邓利维,zh-CN
+Gladius Pirate,短剑 海盗,zh-CN
+Gladius Valiant,短剑 勇士,zh-CN
+Hammerhead,锤头鲨,zh-CN
+Idris,伊德里斯,zh-CN
+Idris-M,伊德里斯-M,zh-CN
+Idris-P,伊德里斯-P,zh-CN
+Javelin,标枪,zh-CN
+Nautilus,鹦鹉螺,zh-CN
+Reclaimer,回收者,zh-CN
+Redeemer,救赎者,zh-CN
+Retaliator,报复者,zh-CN
+Retaliator Bomber,报复者 轰炸,zh-CN
+Sabre,军刀,zh-CN
+Sabre Comet,军刀 彗星,zh-CN
+Sabre Firebird,军刀 火鸟,zh-CN
+Sabre Peregrine,军刀 游隼,zh-CN
+Sabre Raven,军刀 渡鸦,zh-CN
+Vanguard Warden,先锋 典狱长,zh-CN
+Vanguard Harbinger,先锋 先驱,zh-CN
+Vanguard Hoplite,先锋 重装,zh-CN
+Vanguard Sentinel,先锋 哨兵,zh-CN
+Vulcan,火神,zh-CN
+Arrow,箭矢,zh-CN
+Asgard,阿斯加德,zh-CN
+Ballista,弩炮,zh-CN
+Ballista Dunestalker,弩炮 沙丘追猎者,zh-CN
+Ballista Snowblind,弩炮 雪盲,zh-CN
+C8R Pisces Rescue,C8R 双鱼座 救护,zh-CN
+C8X Pisces Expedition,C8X 双鱼座 远征,zh-CN
+C8 Pisces,C8 双鱼座,zh-CN
+Centurion,百夫长,zh-CN
+Crucible,坩埚,zh-CN
+Gladiator,角斗士,zh-CN
+Hawk,猎鹰,zh-CN
+F7A Hornet Mk I,F7A 大黄蜂 Mk I,zh-CN
+F7A Hornet Mk II,F7A 大黄蜂 Mk II,zh-CN
+F7A Mk II,F7A Mk II,zh-CN
+F7A Mk I,F7A Mk I,zh-CN
+F7C Hornet Mk I,F7C 大黄蜂 Mk I,zh-CN
+F7C-M Super Hornet Mk I,F7C-M 超级大黄蜂 Mk I,zh-CN
+F7C-M Hornet Heartseeker Mk I,F7C-M 大黄蜂 寻心者 Mk I,zh-CN
+F7C-M Hornet Heartseeker Mk II,F7C-M 大黄蜂 寻心者 Mk II,zh-CN
+F7C-M Super Hornet Mk II,F7C-M 超级大黄蜂 Mk II,zh-CN
+F7C-M Mk II,F7C-M Mk II,zh-CN
+F7C-M Mk I,F7C-M Mk I,zh-CN
+F7C-R Hornet Tracker Mk I,F7C-R 大黄蜂 追踪者 Mk I,zh-CN
+F7C-R Hornet Tracker Mk II,F7C-R 大黄蜂 追踪者 Mk II,zh-CN
+F7C-R Mk II,F7C-R Mk II,zh-CN
+F7C-R Mk I,F7C-R Mk I,zh-CN
+F7C-S Hornet Ghost Mk I,F7C-S 大黄蜂 幽灵 Mk I,zh-CN
+F7C-S Hornet Ghost Mk II,F7C-S 大黄蜂 幽灵 Mk II,zh-CN
+F7C-S Mk II,F7C-S Mk II,zh-CN
+F7C-S Mk I,F7C-S Mk I,zh-CN
+F7C Hornet Mk II,F7C 大黄蜂 Mk II,zh-CN
+F7C Mk II,F7C Mk II,zh-CN
+F7C Hornet Wildfire Mk I,F7C 大黄蜂 野火 Mk I,zh-CN
+F7C Wildfire Mk I,F7C 野火 Mk I,zh-CN
+F7C Mk I,F7C Mk I,zh-CN
+Hurricane,飓风,zh-CN
+Legionnaire,军团兵,zh-CN
+Liberator,解放者,zh-CN
+F8A Lightning,F8A 闪电,zh-CN
+F8C Lightning,F8C 闪电,zh-CN
+Spartan,斯巴达,zh-CN
+Terrapin,水龟,zh-CN
+Terrapin Medic,水龟 医疗,zh-CN
+Terrapin Medic WSS,水龟 医疗 救助者特别版,zh-CN
+Valkyrie,女武神,zh-CN
+Valkyrie Liberator,女武神 解放者,zh-CN
+ATLS,ATLS,zh-CN
+ATLS GEO,ATLS GEO,zh-CN
+ATLS GEO IKTI,ATLS GEO IKTI,zh-CN
+ATLS IKTI,ATLS IKTI,zh-CN
+ATLS IKTI Rad,ATLS IKTI Rad,zh-CN
+CSV-SM,CSV-SM,zh-CN
+MPUV Cargo,MPUV 货运,zh-CN
+MPUV Tractor,MPUV 牵引,zh-CN
+MPUV Personnel,MPUV 载人,zh-CN
+MOLE,鼹鼠,zh-CN
+MOLE Carbon,鼹鼠 炭黑,zh-CN
+MOLE Talus,鼹鼠 岩白,zh-CN
+RAFT,木筏,zh-CN
+SRV,SRV,zh-CN
+Merchantman,商船,zh-CN
+Defender,防卫者,zh-CN
+HoverQuad,悬浮驷,zh-CN
+Mustang Alpha,野马 阿尔法,zh-CN
+Mustang Beta,野马 贝塔,zh-CN
+Mustang Delta,野马 德尔塔,zh-CN
+Mustang Gamma,野马 伽马,zh-CN
+Mustang Omega,野马 欧米伽,zh-CN
+Nomad,游牧者,zh-CN
+Pioneer,开拓者,zh-CN
+A1 Spirit,A1 星灵,zh-CN
+C1 Spirit,C1 星灵,zh-CN
+E1 Spirit,E1 星灵,zh-CN
+Intrepid,无畏,zh-CN
+Mercury Star Runner,墨丘利 星际快运船,zh-CN
+Mercury,墨丘利,zh-CN
+Ares Star Fighter Inferno,战神 星际战斗机 地狱火,zh-CN
+Ares Inferno,战神 地狱火,zh-CN
+Ares Star Fighter Ion,战神 星际战斗机 离子光,zh-CN
+Ares Ion,战神 离子光,zh-CN
+A2 Hercules Starlifter,大力神 A2 星际运输船,zh-CN
+A2 Hercules,A2 大力神,zh-CN
+C2 Hercules Starlifter,大力神 C2 星际运输船,zh-CN
+C2 Hercules,C2 大力神,zh-CN
+M2 Hercules Starlifter,大力神 M2 星际运输船,zh-CN
+M2 Hercules,M2 大力神,zh-CN
+Genesis Starliner,创世纪 星际航线,zh-CN
+Genesis,创世纪,zh-CN
+Buccaneer,掠夺者,zh-CN
+Caterpillar,毛虫,zh-CN
+KRF Inmate Transport,克莱舍尔 囚犯运输船,zh-CN
+Caterpillar Pirate,毛虫 海盗,zh-CN
+Corsair,海盗船,zh-CN
+Cutlass Black,黑弯刀,zh-CN
+Cutlass Blue,蓝弯刀,zh-CN
+Cutlass Red,红弯刀,zh-CN
+Cutlass Steel,钢弯刀,zh-CN
+Cutter,小刀,zh-CN
+Cutter Rambler,小刀 漫步者,zh-CN
+Cutter Scout,小刀 侦察,zh-CN
+Dragonfly,蜻蜓,zh-CN
+Dragonfly Star Kitten,蜻蜓 星空猫,zh-CN
+Dragonfly Yellowjacket,蜻蜓 黄胡蜂,zh-CN
+Golem,魔像,zh-CN
+Herald,信使,zh-CN
+Herald Blue,蓝信使,zh-CN
+Herald Red,红信使,zh-CN
+Ironclad,铁甲,zh-CN
+Ironclad Assault,铁甲 突袭,zh-CN
+Kraken,海妖,zh-CN
+Kraken Privateer,海妖 私掠,zh-CN
+Mule,骡子,zh-CN
+Vulture,秃鹫,zh-CN
+Blade,刀锋,zh-CN
+Glaive,长刀,zh-CN
+Prowler,徘徊者,zh-CN
+Prowler Utility,徘徊者 多功能,zh-CN
+Talon,利爪,zh-CN
+Talon Shrike,利爪 伯劳,zh-CN
+Syulen,速伦,zh-CN
+MTC,MTC,zh-CN
+PTV,PTV,zh-CN
+ROC,ROC,zh-CN
+ROC-DS,ROC-DS,zh-CN
+STV,STV,zh-CN
+L21 Wolf,L21 狼式,zh-CN
+P-52 Merlin,P-52 梅林,zh-CN
+P-72 Archimedes,P-72 阿基米德,zh-CN
+P-72 Archimedes Emerald,P-72 阿基米德 翡翠绿,zh-CN
+Endeavor,奋进,zh-CN
+Expanse,无垠,zh-CN
+Fortune,财运,zh-CN
+Freelancer,自由枪骑兵,zh-CN
+Freelancer DUR,自由枪骑兵 DUR,zh-CN
+Freelancer MAX,自由枪骑兵 MAX,zh-CN
+Freelancer MIS,自由枪骑兵 MIS,zh-CN
+Hull A,货轮 A,zh-CN
+Hull B,货轮 B,zh-CN
+Hull C,货轮 C,zh-CN
+Hull D,货轮 D,zh-CN
+Hull E,货轮 E,zh-CN
+Odyssey,奥德赛,zh-CN
+Prospector,勘探者,zh-CN
+Razor,剃刀,zh-CN
+Razor EX,剃刀 EX,zh-CN
+Razor LX,剃刀 LX,zh-CN
+Reliant Kore,信赖 基础,zh-CN
+Reliant Mako,信赖 新闻,zh-CN
+Reliant Sen,信赖 科考,zh-CN
+Reliant Tana,信赖 武装,zh-CN
+Starfarer,星际远航者,zh-CN
+Starfarer Gemini,星际远航者 双子座,zh-CN
+Guardian,守护者,zh-CN
+Guardian MX,守护者 MX,zh-CN
+Guardian QI,守护者 QI,zh-CN
+Pulse,脉冲,zh-CN
+Pulse LX,脉冲 LX,zh-CN
+Fury,狂怒,zh-CN
+Fury LX,狂怒 LX,zh-CN
+Fury MX,狂怒 MX,zh-CN
+100i,100i,zh-CN
+125a,125a,zh-CN
+135c,135c,zh-CN
+300i,300i,zh-CN
+315p,315p,zh-CN
+325a,325a,zh-CN
+350r,350r,zh-CN
+400i,400i,zh-CN
+600i Touring,600i 旅行版,zh-CN
+600i,600i,zh-CN
+85X Limited,85X 限量版,zh-CN
+890 Jump,890 跃动,zh-CN
+G12,G12,zh-CN
+G12a,G12a,zh-CN
+G12r,G12r,zh-CN
+X1 Force,X1 武装,zh-CN
+X1 Velocity,X1 竞速,zh-CN
+X1,X1,zh-CN
+M50 Interceptor,M50 截击机,zh-CN
+Apollo Medivac,阿波罗 医疗,zh-CN
+Apollo Triage,阿波罗 分诊,zh-CN
+Arrastra,阿拉斯塔,zh-CN
+Aurora CL,极光 CL,zh-CN
+Aurora ES,极光 ES,zh-CN
+Aurora LN,极光 LN,zh-CN
+Aurora LX,极光 LX,zh-CN
+Aurora MR,极光 MR,zh-CN
+Bengal Carrier,孟加拉航母,zh-CN
+Constellation Andromeda,星座 仙女座,zh-CN
+Constellation Aquila,星座 天鹰座,zh-CN
+Constellation Phoenix Emerald,星座 凤凰座 翡翠绿,zh-CN
+Constellation Phoenix,星座 凤凰座,zh-CN
+Constellation Taurus,星座 金牛座,zh-CN
+Galaxy,银河,zh-CN
+Lynx,天猫座,zh-CN
+Mantis,螳螂,zh-CN
+Merlin,梅林,zh-CN
+Meteor,流星,zh-CN
+Perseus,英仙座,zh-CN
+Polaris,北极星,zh-CN
+Scorpius Antares,天蝎座 蝎心,zh-CN
+Scorpius,天蝎座,zh-CN
+Ursa Medivac,大熊座 医疗,zh-CN
+Ursa Fortuna,大熊座 福尔图娜,zh-CN
+Ursa,大熊座,zh-CN
+Zeus Mk II CL,宙斯 Mk II CL,zh-CN
+Zeus Mk II ES,宙斯 Mk II ES,zh-CN
+Zeus Mk II MR,宙斯 Mk II MR,zh-CN
+Cyclone AA,旋风 AA,zh-CN
+Cyclone MT,旋风 MT,zh-CN
+Cyclone RC,旋风 RC,zh-CN
+Cyclone RN,旋风 RN,zh-CN
+Cyclone TR,旋风 TR,zh-CN
+Cyclone,旋风,zh-CN
+Nova,新星,zh-CN
+Ranger TR,游骑兵 TR,zh-CN
+Storm AA,风暴 AA,zh-CN
+Storm,风暴,zh-CN
+Cleaver,切割者,zh-CN
+Kingship,王船,zh-CN
+Scythe,死镰,zh-CN
+Nox,Nox,zh-CN
+Nox Kue,Nox Kue,zh-CN
+Railen,锐伦,zh-CN
+Khartu-al,卡图,zh-CN
+Khartu Al,卡图,zh-CN
+San'tok.yāi,桑托起亚,zh-CN
+San Tok Yai,桑托起亚,zh-CN
+Carrack,克拉克,zh-CN
+Carrack Expedition,克拉克 远征,zh-CN
+Paladin,圣骑士,zh-CN
+Starlancer MAX,星际枪骑兵 MAX,zh-CN
+Starlancer TAC,星际枪骑兵 TAC,zh-CN

--- a/meta/starcitizen.json
+++ b/meta/starcitizen.json
@@ -1,0 +1,18 @@
+{
+  "id": "starcitizen",
+  "name": "Star Citizen",
+  "description": "星际公民术语库，包含游戏内相关术语的中文翻译。",
+  "author": "Kyan",
+  "glossary": "starcitizen",
+  "langs": ["zh-CN"],
+  "i18ns": {
+    "zh-CN": {
+      "name": "《星际公民》",
+      "description": "星际公民术语库，包含游戏内相关术语的中文翻译。"
+    },
+    "en": {
+      "name": "Star Citizen",
+      "description": "Star Citizen glossary, containing Chinese translations of related terms."
+    }
+  }
+}


### PR DESCRIPTION
Introduces a new glossary for Star Citizen terms with Chinese translations in glossaries/starcitizen.csv and corresponding metadata in meta/starcitizen.json.