### PR TITLE
添加为游戏《鸣潮》定制的术语库

### DIFF
--- a/glossaries/wuthering-waves_zh-CN.csv
+++ b/glossaries/wuthering-waves_zh-CN.csv
@@ -1,0 +1,839 @@
+source,target,tgt_lng
+ATK,攻击力,zh-CN
+Aalto,秋水,zh-CN
+Abnormality,异度,zh-CN
+Abraxas,阿布拉克萨斯,zh-CN
+Absorption,吸收,zh-CN
+Abyss Surges,擎渊怒涛,zh-CN
+Abyssal Echoes,渊海回声,zh-CN
+Academy's Dark Side,学院暗面,zh-CN
+Acolyte,教士,zh-CN
+Adjacent,相邻BUFF,zh-CN
+Aemeath,爱弥斯,zh-CN
+Aero,气动,zh-CN
+Aero Erosion,风蚀效应,zh-CN
+Aero-Type Combat Machine,气动类装置,zh-CN
+Afflatus,灵韵,zh-CN
+Aflame,燃焰,zh-CN
+Afterflame,余火,zh-CN
+Aftersound,余响,zh-CN
+Ages of Harvest,时和岁稔,zh-CN
+Aleph-1,阿列夫-1,zh-CN
+Anchor Obelisk,锚定界石,zh-CN
+Anchor Stone,定向锚,zh-CN
+Anchor's Sigil,心之锚纹,zh-CN
+Anniversary Cake,庆典蛋糕,zh-CN
+Antique,祯祥,zh-CN
+Any Rarity,任意稀有度,zh-CN
+Arsinosa,荣耀狮像,zh-CN
+Ascendancy,权炳,zh-CN
+Ascension,突破,zh-CN
+Ascension Material,突破材料,zh-CN
+Ashen Oath,灰烬血誓,zh-CN
+Ashinohara,苇原,zh-CN
+Asphodel Barrens,往世花平野,zh-CN
+Astrite,星声,zh-CN
+Augment,空灵,zh-CN
+Augusta,奥古斯塔,zh-CN
+Autumntrace,纹秋,zh-CN
+Averardo Bank,埃弗拉德银行,zh-CN
+Avinoleum,阿维纽林,zh-CN
+Awakening,觉醒,zh-CN
+Baizhi,白芷,zh-CN
+Bamboo's Shade,竹照,zh-CN
+Bank,银行,zh-CN
+Banner,卡池,zh-CN
+Baseline Mode,基准模式,zh-CN
+Basic Attack,常态攻击,zh-CN
+Basic Form,白板,zh-CN
+Battle Pass,通行证,zh-CN
+Beam Weapon,【光束】,zh-CN
+Beyond,彼世,zh-CN
+Beyond Imagination,飞跃幻想,zh-CN
+Bjartr Woods,浮光林,zh-CN
+Black Alley,黑街,zh-CN
+Black Shores,黑海岸,zh-CN
+Black Shores Islands,黑海岸群岛,zh-CN
+Blaze,焰光,zh-CN
+Blazing Brilliance,赫奕流明,zh-CN
+Blazing Justice,焰光裁定,zh-CN
+Blazing Star,炽灼之星,zh-CN
+Blessing of the Wan Light,苍白死光的祝颂,zh-CN
+Blightcloud,黑潮云,zh-CN
+Blobflies,飞猎手,zh-CN
+Blobfly,飞猎手,zh-CN
+Bloodpact's Pledge,不屈命定之冠,zh-CN
+Book of Prophecies,「预言书」,zh-CN
+Boost - Coffee's Shelter,「增幅·咖啡守护」,zh-CN
+Boost - Dessert Prep,「增幅·点心制备」,zh-CN
+Boost - Namipon Aid,「增幅·波仔援护」,zh-CN
+Boost - Satisfaction,「增幅·心满意足」,zh-CN
+Boost - Sprint,「增幅·疾驰」,zh-CN
+Border Mountains,分界山,zh-CN
+Boson Astrolabe,玻色子星盘,zh-CN
+Boss,首领,zh-CN
+Brant,布兰特,zh-CN
+Bravo,喝彩,zh-CN
+Breeze Breaker,风息裂象,zh-CN
+Broadblade,阔刃,zh-CN
+Broadblade#41,重破刃-41型,zh-CN
+Budding Mode,含苞状态,zh-CN
+Buff,增益,zh-CN
+Buling,卜灵,zh-CN
+Bullet Time,子弹时间,zh-CN
+Bullet Weapon,【弹道】,zh-CN
+Burning Drive,内燃烧,zh-CN
+Burning Matchpoint,赛点沸腾,zh-CN
+Burning Rhapsody,浮翼狂想,zh-CN
+Burst,爆发,zh-CN
+Burst - Blazing Pillar,「爆发·灼热火柱」,zh-CN
+Burst - Coffee Impact,「爆发·咖啡冲击」,zh-CN
+Burst - Scorching Impact,「爆发·灼热冲击」,zh-CN
+Burst - Shock Impact,「爆发·震荡冲击」,zh-CN
+Cadenza,华彩乐段,zh-CN
+Calamity-Class,海啸级,zh-CN
+Calcharo,卡卡罗,zh-CN
+Camellya,椿,zh-CN
+Camellya,椿,zh-CN
+Cantarella,坎特蕾拉,zh-CN
+Canyons,狭渊,zh-CN
+Capitoline Hill,卡匹托山,zh-CN
+Caracalla Market,卡拉卡拉市场,zh-CN
+Carlotta,珂莱塔,zh-CN
+Carnevale,狂欢节,zh-CN
+Carnevale Event A Decade Ago,十年前的狂欢节事件,zh-CN
+Cartethyia,卡提希娅,zh-CN
+Cathedral of Mercury,水星天,zh-CN
+Celestial Spiral,东落西升,zh-CN
+Celestial Steed,天马座,zh-CN
+Censorate,兰台,zh-CN
+Central Plains,中曲台地,zh-CN
+Cetus the Tidebreaker,溯海之鲸,zh-CN
+Chamber of Discipline,诫令院,zh-CN
+Changli,长离,zh-CN
+Channel,信道,zh-CN
+Chi,气,zh-CN
+Chimera,奇美拉,zh-CN
+Chixia,炽霞,zh-CN
+Chop Chop,浮灵偶,zh-CN
+Chronosorter,时序器,zh-CN
+Ciaccona,夏空,zh-CN
+Cinema Solaris,索拉电影院,zh-CN
+Civilization Simulation Sand Table,文明模拟沙盘,zh-CN
+Cliffside Harbor,崖港,zh-CN
+Clockwork Illuminator,发条灯偶,zh-CN
+Cloud Chasm Valley,云陵谷,zh-CN
+Collapsed Core,坍缩核,zh-CN
+Colosseum Olymdos,奥林匹斯竞技场,zh-CN
+Combo - Dessert Strike,「连击·甜品打击」,zh-CN
+Combo - Dessert Strike: Enhanced,「连击·甜品打击·强」,zh-CN
+Combo - Rice Dango Missile,「连击·米团飞弹」,zh-CN
+Combo - Rice Dango Missile: Enhanced,「连击·米团飞弹·强」,zh-CN
+Combo - Support Missile,「连击·援护飞弹」,zh-CN
+Combo - Support Missile: Enhanced,「连击·援护飞弹·强」,zh-CN
+Common-Class,轻波级,zh-CN
+Companion Story,传说任务,zh-CN
+Concentration,念意,zh-CN
+Concerto,协奏,zh-CN
+Concerto Energy,协奏能量,zh-CN
+Congenital,先天型,zh-CN
+Congenital Resonator,先天型共鸣者,zh-CN
+Connoisseur Channel,鉴赏频道,zh-CN
+Convene,唤取,zh-CN
+Convenes,唤取,zh-CN
+Convergent,回声,zh-CN
+Conviction,决意,zh-CN
+Copper Mirror,铜镜,zh-CN
+Core,核心,zh-CN
+Cosmic Ripples,漪澜浮录,zh-CN
+COST,COST,zh-CN
+Court of Savantae,稷廷,zh-CN
+Cristoforo,克里斯托弗,zh-CN
+Crit DMG,暴击伤害,zh-CN
+Crit Rate,暴击率,zh-CN
+Critical State,危险状态,zh-CN
+Crown of Wills,以众愿为冕,zh-CN
+Crownless,无冠者,zh-CN
+Cube,团子,zh-CN
+Daily Coupon,每日乐园券,zh-CN
+Danjin,丹瑾,zh-CN
+Dark Surge,暗涌,zh-CN
+Dark Tide,黑潮,zh-CN
+Dark Tide,黑潮,zh-CN
+Dark Tide Creation,黑潮造物,zh-CN
+Data Bank,数据坞,zh-CN
+Data Fusion,数据融合,zh-CN
+Data Restructuring,数据重构,zh-CN
+Dauntless Evernight,永夜长明,zh-CN
+Dawnlit Keep,日辉庇覆,zh-CN
+Daybreaker's Spine,破晓之脊,zh-CN
+Debuff,减益,zh-CN
+Decipher,解读,zh-CN
+Deconstruction,解离,zh-CN
+Deep Water Zone,深水层,zh-CN
+DEF,防御力,zh-CN
+Defier's Thorn,星序,zh-CN
+Demon Hypostasis,恶魔位格,zh-CN
+Dengdeng,灯灯,zh-CN
+Denia,达妮娅,zh-CN
+Designed Resonator,定制共鸣者,zh-CN
+Desorock Highland,荒石高地,zh-CN
+Devour,吞噬,zh-CN
+Dim Forest,无光之森,zh-CN
+Discord,不绝余音,zh-CN
+Dispersion,变彩,zh-CN
+Divergent,专注,zh-CN
+Divine Voice,福音,zh-CN
+DMG Enhancement,伤害提高,zh-CN
+Dodge Counter,闪避还击,zh-CN
+DPS,主C,zh-CN
+Dream Block: Gravel,梦块·沙石碎域,zh-CN
+Dream Block: Ice Shards,梦块·冰晶碎域,zh-CN
+Dream Block: Obsidian,梦块·黑石碎域,zh-CN
+Dream Block: Watermirror,梦块·水镜碎域,zh-CN
+Dream of Connection,共通之梦,zh-CN
+Dream of Devouring,吞噬之梦,zh-CN
+Dream of Exchange,换取之梦,zh-CN
+Dream of Gradation,递变之梦,zh-CN
+Dream of Integration,融合之梦,zh-CN
+Dreamborne: Roseshroom,异梦·刺玫菇,zh-CN
+Dreaming Round n' Round,梦境，转转转,zh-CN
+Dreamland Coupon,乐园券,zh-CN
+Dreamscape Train,梦境列车,zh-CN
+Dreamy Firework,礼花炮,zh-CN
+Earthrend Wedge,彻地之楔,zh-CN
+Ebony Gatekeeper,黑色守门人,zh-CN
+Echo,声骸,zh-CN
+Echo Brooder,声骸培育舱,zh-CN
+Echo Gladiating,声骸角斗,zh-CN
+Echo Recruitment,声骸征聘,zh-CN
+Echo Skill,声骸技能,zh-CN
+Echoes,声骸,zh-CN
+Echo-Type Combat Machine,声骸类装置,zh-CN
+Electro,导电,zh-CN
+Electro Flare,电磁效应,zh-CN
+Electro Rage,电磁爆发,zh-CN
+Electro-Type Combat Machine,导电类装置,zh-CN
+Elemental DMG Bonus,属性伤害加成,zh-CN
+Elite-Class,巨浪级,zh-CN
+Emerald of Genesis,千古洑流,zh-CN
+Emerald Sentence,翠墨判言,zh-CN
+Encapsulated,凝语,zh-CN
+Encore,安可,zh-CN
+Endgame,终局内容,zh-CN
+Endnotes on the Endgame,终局之释义,zh-CN
+Energy Regen,共鸣效率,zh-CN
+Enflamement,离火,zh-CN
+Enhancement Field,范围强化,zh-CN
+Ensemble Sylph,合奏音影,zh-CN
+Ephor,监察官,zh-CN
+Etching Plains,蚀刻平原,zh-CN
+Eternal Hypostasis,永恒位格,zh-CN
+Etheric Sea,乙太之海,zh-CN
+Euphonia,天籁,zh-CN
+Event Convene,活动唤取,zh-CN
+Everbright Polestar,恒明北辰,zh-CN
+Exchange,换取,zh-CN
+Exile,流放者,zh-CN
+Exiles,流放者,zh-CN
+Exostrider,星际行者,zh-CN
+Exoswarm,隧群,zh-CN
+Exoswarm Material,隧群元件,zh-CN
+Expedition Motorbike,科考摩托,zh-CN
+Exploration Progress,探索度,zh-CN
+Exploration Quest,探索任务,zh-CN
+Explosive Omen,爆裂征兆,zh-CN
+Fabianum,法比亚纳,zh-CN
+Fabricatorium,源塑工厂,zh-CN
+Fabricatorium of the Deep,隐海试验场,zh-CN
+Fangspire Chasm,牙尖裂谷,zh-CN
+Feilian Shock,飞廉冲击,zh-CN
+Fengyiquan,风仪拳,zh-CN
+Fenrico the First,芬莱克一世,zh-CN
+Figurine: Clang Bang,乐园人偶·叮咚咚,zh-CN
+Figurine: Conductor,乐园人偶·指挥家,zh-CN
+Figurine: Excarat,乐园人偶·遁地鼠,zh-CN
+Figurine: Gulpuff,乐园人偶·咕咕河豚,zh-CN
+Fisalia,翡萨烈,zh-CN
+Fisalia Family,翡萨烈家族,zh-CN
+Fission Junrock,裂变幼岩,zh-CN
+Five Thunders Spell Array,五雷荡煞阵,zh-CN
+Fleurdelys,芙露德莉斯,zh-CN
+Flight,翱翔,zh-CN
+Fluctuating Voidmatter Levels,虚质不稳态,zh-CN
+Forgery Challenge,凝素领域,zh-CN
+Forging Tide,铸潮波纹,zh-CN
+Forte,共鸣回路,zh-CN
+Forte Examination Report,共鸣检测报告,zh-CN
+Forte Upgrade,共鸣回路强化,zh-CN
+Fortes,共鸣回路,zh-CN
+Fortune Bell,幸运摇铃,zh-CN
+Fractsidus,残星会,zh-CN
+Frequency,频率,zh-CN
+Frequency Cassette Recorder,频录装置,zh-CN
+Frequency Crystal,频率晶体,zh-CN
+Full Stop,句点,zh-CN
+Fusion,热熔,zh-CN
+Fusion Burst,聚爆效应,zh-CN
+Fusion Cube,聚变魔方,zh-CN
+Fusion Trail,聚爆轨迹,zh-CN
+Fusion-Type Combat Machine,热熔类装置,zh-CN
+Gacha,抽卡,zh-CN
+Galbrena,嘉贝莉娜,zh-CN
+Gate of Quandary,虚实之门,zh-CN
+Gauntlets,臂铠,zh-CN
+Gauntlets#21D,钢影拳-21丁型,zh-CN
+Geshu Lin,哥舒临,zh-CN
+Ghost Hounds,猎犬佣兵团,zh-CN
+Giant's Gaze,巨目远野,zh-CN
+Glacier,冰川,zh-CN
+Glacio,凝冽,zh-CN
+Glacio Chafe,霜渐效应,zh-CN
+Glacio-Type Combat Machine,冷凝类装置,zh-CN
+Gladiator,角斗士,zh-CN
+Gladiators,角斗士,zh-CN
+Glide,滑翔,zh-CN
+Glittering Ray,闪映华光,zh-CN
+Glory,荣光,zh-CN
+Golden Anthem,黄金之歌,zh-CN
+Gradation,递变,zh-CN
+Grand Architect,残星会会长,zh-CN
+Grand Library,瑝览类书,zh-CN
+Grand Marshal,本兵,zh-CN
+Grapple,钩索,zh-CN
+Gravity Loss,失重,zh-CN
+Great Agon,大角斗赛,zh-CN
+Greatsword,巨剑,zh-CN
+Griffrex,狩王鹫,zh-CN
+Gryphon's Fortress,鹫巢石城,zh-CN
+Guardian Echo,守护兽声骸,zh-CN
+Guardian's Lament,大海的馈赠,zh-CN
+Harbinger,代行者,zh-CN
+Havoc,湮灭,zh-CN
+Havoc Bane,虚湮效应,zh-CN
+Hazard Zone,危域,zh-CN
+Hazy Dream,迷梦,zh-CN
+Healer,治疗,zh-CN
+Heart of Virtue,人权之心,zh-CN
+Heartpour,饮心,zh-CN
+Heavenfall Edict: Unbound,星辉破界而来·于此释放,zh-CN
+Heavy Attack,重击,zh-CN
+Heliacal Ember,烈阳余烬,zh-CN
+Heliogyre,日轮,zh-CN
+Helios,赫利俄斯,zh-CN
+Hero of Heroes,「英雄王」,zh-CN
+Heroic Epic of Valor,无惧浪涛之勇,zh-CN
+Hero's Legacy Armor,古英雄铠,zh-CN
+High Syntony Field,强谐振场,zh-CN
+High Tide,涨潮期,zh-CN
+Hiyuki,绯雪,zh-CN
+Hollow Figure,蚀像,zh-CN
+Holmleaf Medal,槲叶勋章,zh-CN
+Hologram Challenge,全息战略,zh-CN
+Homeland Civilization,故乡文明,zh-CN
+Hongzhen Village,虹镇,zh-CN
+Hoochief Cyclone,嚣风戏猿,zh-CN
+Hornett,猎号,zh-CN
+House Silva,西尔瓦家,zh-CN
+Howler,啸叫,zh-CN
+HP,生命值,zh-CN
+Huanglong,瑝珑,zh-CN
+Huaxu Academy,华胥研究院,zh-CN
+Hunt,狩猎,zh-CN
+Hunting Trap,猎手陷阱,zh-CN
+Hyvatia,海维夏,zh-CN
+Ice Prism,冰棱,zh-CN
+Ice Thorn,冰棘,zh-CN
+Ichor,日髓,zh-CN
+Ichor Blade,日髓碎刃,zh-CN
+Ichor Deposit,日髓阵列,zh-CN
+Ichor Flow,日髓能流,zh-CN
+i-frame,无敌帧,zh-CN
+Illusory Dream,「幻梦」,zh-CN
+Imagination,想象力,zh-CN
+Immersive Mode,沉浸模式,zh-CN
+Imperator,英白拉多,zh-CN
+Incandescence,韶光,zh-CN
+Incarnation,乘岁凌霄,zh-CN
+Incinerating Will,朱蚀之刻,zh-CN
+Induced Resonator,诱导型共鸣者,zh-CN
+Inferno Mode,灼焰形态,zh-CN
+Infirmary,医务室,zh-CN
+Inksplash of Mind,淋漓醉墨,zh-CN
+Innate Gift?,「天赋？」,zh-CN
+Insider Channel,内测频道,zh-CN
+Instant Response,即刻响应,zh-CN
+Integration,融合,zh-CN
+Interfered Marker,干涉标记,zh-CN
+Internal Security Agency,镇抚司,zh-CN
+Intimacy Level,好感度,zh-CN
+Intro Skill,变奏技能,zh-CN
+Intuition,洞见,zh-CN
+Irideglow,虹光,zh-CN
+Irideglow Crystal,虹晶,zh-CN
+Isomer Bolt,异构飞弹,zh-CN
+Item of Exchange,换取之物,zh-CN
+Iuno,尤诺,zh-CN
+Ivory Doorkeeper,白色守门人,zh-CN
+Jianxin,鉴心,zh-CN
+Jinhsi,今汐,zh-CN
+Jinzhou,今州,zh-CN
+Jinzhou Counselor,今州参事,zh-CN
+Jinzhou Patroller,今巡尉,zh-CN
+Jiyan,忌炎,zh-CN
+Judgement Points,审判值,zh-CN
+Jué,角,zh-CN
+Kaleidoscope,镜中万花,zh-CN
+Kaleidoscopic Parade,绮彩巡游,zh-CN
+Kumokiri,云切,zh-CN
+KU-Money's Shop,库默尼商行,zh-CN
+Kuro Games,库洛游戏,zh-CN
+Lahai-Roi,拉海洛,zh-CN
+Land of Xuanfang,玄方地界,zh-CN
+Laser Shearer,镭射切变,zh-CN
+Laureate,桂冠者,zh-CN
+Laurel,桂冠,zh-CN
+Lawless Zone,法外之地,zh-CN
+Left Behind,往人,zh-CN
+Leihuangquan,雷煌拳,zh-CN
+Lethean Elegy,幽冥的忘忧章,zh-CN
+Level Cap,等级上限,zh-CN
+Leviathan,利维亚坦,zh-CN
+Lifethread - Jetstream,命弦·本流,zh-CN
+Lillibet,莉莉贝,zh-CN
+Lingyang,凌阳,zh-CN
+Lion Head,狮首,zh-CN
+Liondance,狮子舞,zh-CN
+Liondance Troupe,瑞狮团,zh-CN
+Lollo Logistics,呜呜物流,zh-CN
+Longings,余念,zh-CN
+Loong Whiskers Crisp,龙须酥,zh-CN
+Lucilla,洛瑟拉,zh-CN
+Lucky Coin,幸运币,zh-CN
+Lucky Draw,问祯,zh-CN
+Lumiflow,流光,zh-CN
+Lumingloss,清音异响,zh-CN
+Luminous Hymn,和光回唱,zh-CN
+Lunar Cycle,月相流转,zh-CN
+Lunite,月相,zh-CN
+Lupa,露珀,zh-CN
+Lustrous Razor,浩境粼光,zh-CN
+Lustrous Tide,唤声涡纹,zh-CN
+Luuk Herssen,陆·赫斯,zh-CN
+Lux & Umbra,隐世回光,zh-CN
+Lynae,琳奈,zh-CN
+Maestro,指挥状态,zh-CN
+Magic Box,珍奇箱,zh-CN
+Magistrate,令尹,zh-CN
+Magistrate of Jinzhou,今令尹,zh-CN
+Magistrate's Bodyguard,令尹近卫,zh-CN
+Main Quest,主线任务,zh-CN
+Majesty,威慑,zh-CN
+Mandate of Divinity,神权之意,zh-CN
+Manes Deep,玛涅斯之底,zh-CN
+Manifestation,显像,zh-CN
+Marcato,呼啸重音,zh-CN
+Maroonwood,赤林猎场,zh-CN
+Marvis Industry,玛尔斯工业,zh-CN
+Master Xuanmiao,玄渺真人,zh-CN
+Mawburrow Desert,隐喙深腹,zh-CN
+Meditations of Mercy,容赦的沉思录,zh-CN
+Melody,旋律,zh-CN
+Mengzhou,梦州,zh-CN
+Mesona,醒真草,zh-CN
+Midnight Rangers,夜归,zh-CN
+Mindsight,心镜,zh-CN
+Minerva's Treasure,密涅瓦宝藏,zh-CN
+Mingting,明庭,zh-CN
+Ministry of Development,天工,zh-CN
+Ministry of Sentinel Affairs,谛天鉴,zh-CN
+Ministry of War,军策府,zh-CN
+Mirage,蜃境状态,zh-CN
+Missing Namipons,迷途波仔,zh-CN
+Mist,雾气,zh-CN
+Modulator,调律者,zh-CN
+Module Adapter,模块架构器,zh-CN
+Moldable Crystal,可塑晶质,zh-CN
+Montelli,莫塔里,zh-CN
+Montelli Family,莫塔里家族,zh-CN
+Moongazer's Sigil,轻云出月,zh-CN
+Mornye,莫宁,zh-CN
+Morph Painting,流彩溢形,zh-CN
+Morph Weapon,【特型】,zh-CN
+Mortefi,莫特斐,zh-CN
+Mourning Aix,哀声鸷,zh-CN
+Mt. Firmament,乘霄山,zh-CN
+Murmurstown,呓语镇,zh-CN
+Musical Essence,音律,zh-CN
+Mutant,变异型,zh-CN
+Mutant Resonator,突变型共鸣者,zh-CN
+Namipon,波仔,zh-CN
+Natural,自然型,zh-CN
+Natural Resonator,自然型共鸣者,zh-CN
+Necrostar,噬亡星,zh-CN
+Negative Status,异常效应,zh-CN
+Negative Status DMG,异常效应伤害,zh-CN
+Neon Tower,虹音塔,zh-CN
+New Federation,新联邦,zh-CN
+New Solar Celebration,换日庆典,zh-CN
+New Solar Ceremony,换日仪式,zh-CN
+Nightmare Tacet Discord,梦魇残象,zh-CN
+Norfall Barrens,北落野,zh-CN
+Novialle Regenerative Group,诺维尔再生医药,zh-CN
+Oath of Silence,缄默之誓,zh-CN
+Observation Marker,观测标记,zh-CN
+Open World,开放世界,zh-CN
+Optical Sampling Stage,「光学取样」阶段,zh-CN
+Oracle Engine,岁主,zh-CN
+Order of the Deep,隐海修会,zh-CN
+Order of the Deep,隐海修会,zh-CN
+Originite: Type I,源能长刃・测壹,zh-CN
+Originite: Type II,不归孤军,zh-CN
+Originite: Type III,无眠烈火,zh-CN
+Originite: Type IV,源能臂铠・测肆,zh-CN
+Originite: Type V,今州守望,zh-CN
+Outer Stellarealm,浅析星域,zh-CN
+Outrider,踏白,zh-CN
+Outro Skill,延奏技能,zh-CN
+Ovathrax,无妄者,zh-CN
+Overclock,超频,zh-CN
+Overclocking,超频,zh-CN
+Overdash,飞檐,zh-CN
+Overflow,溢彩,zh-CN
+Overlord-Class,怒涛级,zh-CN
+Overseer,会监,zh-CN
+Overseers,会监,zh-CN
+Overture,行进序曲,zh-CN
+Pack Hunt,追猎,zh-CN
+Pangu Terminal,盘古终端,zh-CN
+Pangu Terminal,盘古终端,zh-CN
+Paradimensional Tacet Field,异维无音区,zh-CN
+Parry,弹刀,zh-CN
+Patrol Station,巡宁所,zh-CN
+Patroller,巡尉,zh-CN
+Perception,感知,zh-CN
+Perfect Dodge,极限闪避,zh-CN
+Pero,佩洛,zh-CN
+Phantasmic Imprint,鹤影,zh-CN
+Phantom,幻象,zh-CN
+Phantoms,幻象,zh-CN
+Phaser,光炮,zh-CN
+Phasic Homogenizer,相位涟漪,zh-CN
+Phoebe,菲比,zh-CN
+Photo Mode,相机模式,zh-CN
+Photochromic Flux,光致变染,zh-CN
+Photosynthesis Energy,光合能量,zh-CN
+Phrolova,弗洛洛,zh-CN
+Pilgrimage,朝圣,zh-CN
+Pioneer Association,先行公约,zh-CN
+Pioneer Podcast,漂泊日志,zh-CN
+Pistols,佩枪,zh-CN
+Pistols#26,穿击枪-26型,zh-CN
+Pity,保底,zh-CN
+Pity System,保底机制,zh-CN
+Play,剧本,zh-CN
+Port City of Guixu,归墟港市,zh-CN
+Porto-Veno Castle,波蒂维诺堡,zh-CN
+Power of Discord,异权之力,zh-CN
+Priest,祭司,zh-CN
+Priestess,谕女,zh-CN
+Primus,主教,zh-CN
+Prism,棱镜,zh-CN
+Prowess,战势,zh-CN
+Public Echo,公共声骸,zh-CN
+Public Security Bureau,治安署,zh-CN
+Pull,抽卡,zh-CN
+Pulsation Bracer,脉动护腕,zh-CN
+Purging Flame,净炼火,zh-CN
+Puzzle,解谜,zh-CN
+Qichi Village,祈池村,zh-CN
+Qingloong Mode,破阵状态,zh-CN
+Qiuyuan,仇远,zh-CN
+Questless Knight,巡游骑士,zh-CN
+Rabelle Cassette,拉贝尔磁带,zh-CN
+Rabelle's Curve,拉贝尔曲线,zh-CN
+Radiance Cleaver,辉光劈斩者,zh-CN
+Radiant Tide,浮金波纹,zh-CN
+Rage Against the Statue,重塑雕像的拳砾,zh-CN
+Ragunna,拉古那,zh-CN
+Rampant Fire,无序暗火,zh-CN
+Rate-up,UP,zh-CN
+Reactor Drive,炉芯,zh-CN
+Ready Stance,准备架势,zh-CN
+Rebirth Uplands,复生丘原,zh-CN
+Rectifier,音感仪,zh-CN
+Rectifier#25,鸣动仪-25型,zh-CN
+Red Light Mode,红灯模式,zh-CN
+Red Spring,裁春,zh-CN
+Redundant Energy,冗余动能,zh-CN
+Reflection,折影,zh-CN
+Reincarnate,重世,zh-CN
+Relative Momentum,【相对动能】,zh-CN
+Remnant,回音,zh-CN
+Remnant Energy,回音能量,zh-CN
+Remove,移除,zh-CN
+Requiem Paradise,安魂乐园,zh-CN
+Rerun,复刻,zh-CN
+Resolve,破阵值,zh-CN
+Resolving Chord,定音,zh-CN
+Resonance Ability,共鸣能力,zh-CN
+Resonance Beacon,共鸣信标,zh-CN
+Resonance Chain,共鸣链,zh-CN
+Resonance Cord,共鸣索,zh-CN
+Resonance Energy,共鸣能量,zh-CN
+Resonance Liberation,共鸣解放,zh-CN
+Resonance Nexus,共鸣枢纽,zh-CN
+Resonance Rate,共鸣率,zh-CN
+Resonance Skill,共鸣技能,zh-CN
+Resonance Spectrum,共鸣频谱,zh-CN
+Resonance Spectrum Pattern,共鸣频谱图样,zh-CN
+Resonant Calcite,共鸣方解石,zh-CN
+Resonator,共鸣者,zh-CN
+Resonators,共鸣者,zh-CN
+Rest Mass Energy,【静质量能】,zh-CN
+Retroact Rain,溯洄雨,zh-CN
+Retroact Rain,溯洄雨,zh-CN
+Reverberation,残响,zh-CN
+Reverberation,残响,zh-CN
+Reverse Overclock,逆超频,zh-CN
+Rime-Draped Sprouts,琼枝冰绡,zh-CN
+Rinascita,黎那汐塔,zh-CN
+Ring of Chainsaw,锯环残响,zh-CN
+Ring of Mirrors,镜之环,zh-CN
+Rite of Return,归源之仪,zh-CN
+Riverside Games,竞渡会,zh-CN
+Roccia,洛可可,zh-CN
+Rocksteady Shield,磐岩护壁,zh-CN
+Roguelike,肉鸽,zh-CN
+Romance in Farewell,叙别的罗曼史,zh-CN
+Romance in Farewell,叙别的罗曼史,zh-CN
+Rooted,定身,zh-CN
+Roseshroom,刺玫菇,zh-CN
+Rotation,循环,zh-CN
+Rover,漂泊者,zh-CN
+Roya,罗伊,zh-CN
+Roya Tribe,罗伊族,zh-CN
+Royan,罗伊人,zh-CN
+Ruby Blossom,彤华,zh-CN
+Ruler's Realm,王之界域,zh-CN
+Rune,符文,zh-CN
+Rupturous Trail,震谐轨迹,zh-CN
+Rushing Wuthers,飞逝骇行,zh-CN
+Sacred Flame,圣火,zh-CN
+Same Row,同行,zh-CN
+Sanguine Wheel,猩红轮链,zh-CN
+Sanguis Plateaus,桑古伊斯狩原,zh-CN
+Sanhua,散华,zh-CN
+Saturation Fire,饱和火力,zh-CN
+Scar,伤痕,zh-CN
+Schwarzloch,会长,zh-CN
+Sealed Tube,密音筒,zh-CN
+Second Coming of Solaris,第二索拉,zh-CN
+Second Resonance Awakening,二次共鸣觉醒,zh-CN
+Senate,元老院,zh-CN
+Sentience,灵性,zh-CN
+Sentinel,岁主,zh-CN
+Sentinel Jué,岁主·角,zh-CN
+Sentinels,岁主,zh-CN
+Septimont,七丘,zh-CN
+Seraphic Duet,光翼共奏,zh-CN
+Shell Credit,贝币,zh-CN
+Shelter Home,悲田院,zh-CN
+Shepherd,牧者,zh-CN
+Side Quest,支线任务,zh-CN
+Sigrika,西格莉卡,zh-CN
+Silent Lightning,雷闪无息,zh-CN
+Silver Bullet,银弹攻势,zh-CN
+Simulation Challenge,模拟领域,zh-CN
+Sinflame,罪火,zh-CN
+Sinner's Mark,缚罪标记,zh-CN
+Skill Level,技能等级,zh-CN
+Skin,皮肤,zh-CN
+SkyArk Space Station,天槎空间站,zh-CN
+Snapshot,快照,zh-CN
+Snowfluff Seal,雪绒海豹,zh-CN
+Solaris,索拉里斯,zh-CN
+Solaris Film Festival,索拉电影节,zh-CN
+Solaris-3,索拉里斯,zh-CN
+Solis,「烈日」酒馆,zh-CN
+Soliskin,日灵,zh-CN
+Soliskin Vitality,日灵能量,zh-CN
+Solistrees,日树,zh-CN
+Solisylum,引日殿,zh-CN
+Solo Concert,音律独奏,zh-CN
+Solsworn,圣誓者,zh-CN
+Solsworn Ciphers,昭日译注,zh-CN
+Somnoire,心之集域,zh-CN
+Sonance Casket,声匣,zh-CN
+Sonance Caskets,声匣,zh-CN
+Sonar,寻音声呐,zh-CN
+Sonata Effect,合鸣效果,zh-CN
+Sonata Effects,合鸣效果,zh-CN
+Sonoro Sphere,索诺拉,zh-CN
+Sonoro Spheres,索诺拉,zh-CN
+Spacetrek Collective,深空联合,zh-CN
+Spectro,衍射,zh-CN
+Spectro Frazzle,光噪效应,zh-CN
+Spectrum Blaster,溢彩荧辉,zh-CN
+Spray Paint,颜料,zh-CN
+Stagger Resistance,霸体,zh-CN
+Stagnant Run,停滞河道,zh-CN
+Stamp Book,集章纪念册,zh-CN
+Standard Convene,常驻唤取,zh-CN
+Stardust Resonance,星屑共振,zh-CN
+Starfield Calibrator,宙算仪轨,zh-CN
+Starflower,星星花,zh-CN
+Starflux,流溢辉光,zh-CN
+Starlume Acceleration,流光增幅,zh-CN
+Startorch Academy,星炬学院,zh-CN
+Starward Riseway,联运椎骨,zh-CN
+Static Mist,停驻之烟,zh-CN
+Status - Waveworn Bane,「异常·海蚀净除」,zh-CN
+Stellar Symphony,协响,zh-CN
+Stellarealm,星域,zh-CN
+Stonard,金掌,zh-CN
+Stonewall Bracer,坚岩斗士,zh-CN
+Stridergate,隧门,zh-CN
+Striding Lion,行狮,zh-CN
+Stringmaster,掣傀之手,zh-CN
+Sub-DPS,副C,zh-CN
+Substance,灵萃,zh-CN
+Summon Weapon,【召唤】,zh-CN
+Supply Chest,物资箱,zh-CN
+Support,辅助,zh-CN
+Surprise Box,惊喜盲盒,zh-CN
+Sword,迅刀,zh-CN
+Sword of Discord's Shadow,异权剑之影,zh-CN
+Sword of Divinity's Shadow,神权剑之影,zh-CN
+Sword of Virtue's Shadow,人权剑之影,zh-CN
+Sword#18,瞬斩刀-18型,zh-CN
+Swordster's Soliloquy,挑灯问剑,zh-CN
+Sworn Allegiance,俯首之刻,zh-CN
+Sync Strike,合击·突刺,zh-CN
+Synchronist,适格者,zh-CN
+Synchronization Rate,同步率,zh-CN
+Synergistic Evo,可助力进化,zh-CN
+Syntony Field,谐振场,zh-CN
+Tacet Core,声核,zh-CN
+Tacet Discord,残象,zh-CN
+Tacet Discord Nest,残象巢穴,zh-CN
+Tacet Discords,残象,zh-CN
+Tacet Field,无音区,zh-CN
+Tacet Fields,无音区,zh-CN
+Tacet Mark,声痕,zh-CN
+Tacet Marks,声痕,zh-CN
+Tacetite,黑石,zh-CN
+Taoqi,桃祈,zh-CN
+Team,战队,zh-CN
+Team Composition,队伍搭配,zh-CN
+Telekinesis,控物,zh-CN
+Tempest Cliffs,风潮崖,zh-CN
+Temporal Disruption,时序紊乱,zh-CN
+Terminal,终端,zh-CN
+Tethys,泰缇斯,zh-CN
+Tethys Abyss,泰缇斯之底,zh-CN
+Tetragon Temple,四方殿,zh-CN
+The Black Shores,黑海岸,zh-CN
+The Fractsidus,残星会,zh-CN
+The Golden Bough,《金枝记》,zh-CN
+The Heliodic Six,秘日六席,zh-CN
+The Lament,悲鸣,zh-CN
+The Lament,悲鸣,zh-CN
+The Last Dance,死与舞,zh-CN
+The Lost Beyond,失亡彼岸,zh-CN
+The Other Side of the Dream,「梦的彼岸」,zh-CN
+The Second Dark Tide,第二次黑潮,zh-CN
+The Shepherd,牧羊人,zh-CN
+The Shorekeeper,守岸人,zh-CN
+The Shorekeeper,守岸人,zh-CN
+Theatrical Moment,戏中人生,zh-CN
+Thermobaric Bullets,热压弹,zh-CN
+Thread of Bane,虚湮之线,zh-CN
+Threnodian,鸣式,zh-CN
+Threnodians,鸣式,zh-CN
+Threnodian's Gem,鸣式宝石,zh-CN
+Threshold State,阈限状态,zh-CN
+"Thunder Spell - Heaven, Earth, Mind",雷法·三才合一,zh-CN
+Thunderbolt,奔雷,zh-CN
+Thunderflare Dominion,驭冕铸雷之权,zh-CN
+Tidal Blight,潮蚀,zh-CN
+Tidal Chorus,潮生之声,zh-CN
+Tidal Heritage,潮遗,zh-CN
+Tiger's Maw,虎口山脉,zh-CN
+Tower of Adversity,逆境深塔,zh-CN
+Tragicomedy,悲喜剧,zh-CN
+Treasure Chest,宝箱,zh-CN
+Trigram,卦象,zh-CN
+Troupe of Fools,愚人剧团,zh-CN
+True Color,本色,zh-CN
+True Lament,真悲鸣,zh-CN
+True Sight,心眼,zh-CN
+Truthseeker's Pass,叩天关,zh-CN
+Tune Break,【谐度破坏】,zh-CN
+Tune Rupture - Interfered,【震谐·干涉】,zh-CN
+Tune Rupture - Shifting,【震谐·偏移】,zh-CN
+Tune Strain - Interfered,【集谐·干涉】,zh-CN
+Tune Strain - Shifting,【集谐·偏移】,zh-CN
+Tuning,调谐,zh-CN
+Ultra Flight Boost,滑翔加速,zh-CN
+Unflickering Valor,不灭航路,zh-CN
+Union Level,联觉等级,zh-CN
+Unseen Snare,虚无绞痕,zh-CN
+Utterance of Marvels,万象新声,zh-CN
+Vainglory Waltz,虚饰的华尔兹,zh-CN
+Vale of Glory,荣耀之谷,zh-CN
+Vanguard Junrock,先锋幼岩,zh-CN
+Variation,奇幻变奏,zh-CN
+Velvet Dream,「紫绒梦」,zh-CN
+Verdant Summit,苍鳞千嶂,zh-CN
+Verina,维里奈,zh-CN
+Verity's Handle,诸方玄枢,zh-CN
+Vibration Strength,共振度,zh-CN
+Vibration Strength,共振度,zh-CN
+Viewpoint,观景点,zh-CN
+Violet-Feathered Heron,紫羽鹭,zh-CN
+Void Storm,虚质磁暴,zh-CN
+Voidmatter Barrier,虚质防壁,zh-CN
+Voidspace,虚质空间,zh-CN
+Voidworm,虚诞虫,zh-CN
+Volatile Note,乐声,zh-CN
+Vortex's Eye,涡心,zh-CN
+Wall Dash,纵跑,zh-CN
+Wastelands,受蚀地,zh-CN
+Waveplate,结晶波片,zh-CN
+Waveplates,结晶波片,zh-CN
+Waves of Acclaims,涛声喝彩,zh-CN
+Waveworn Phenomenon,海蚀现象,zh-CN
+Waveworn Phenomenon,海蚀现象,zh-CN
+Waxing Moon,月满今时,zh-CN
+Waymark Beacon,借位信标,zh-CN
+Waypoint,传送点,zh-CN
+Waystone,路标刻像,zh-CN
+Weapon Ascension,武器突破,zh-CN
+Weapon Projection,武器投影,zh-CN
+Weekly Boss,周本,zh-CN
+Whining Aix's Mire,怨鸟泽,zh-CN
+Whisperin,呓语,zh-CN
+Whispers of Sirens,海的呢喃,zh-CN
+Wide Field Observation Mode,广域观测模式,zh-CN
+Wildfire Mark,燎原之焰,zh-CN
+Wind Chime,定风铎,zh-CN
+Windstring,弦风息,zh-CN
+Wolfaith,狼魂,zh-CN
+Wolflame,狼焰,zh-CN
+Woodland Aria,林间的咏叹调,zh-CN
+Woven Myriad - Convergence,万缕·汇终,zh-CN
+Wuming Bay,无明湾,zh-CN
+Wuthering Waves,鸣潮,zh-CN
+Xiangli Yao,相里要,zh-CN
+Yangyang,秧秧,zh-CN
+Yellow Light Mode,黄灯模式,zh-CN
+Yinlin,吟霖,zh-CN
+Yin-Yang Balance,阴阳相生,zh-CN
+Youhu,釉瑚,zh-CN
+You'tan,忧昙,zh-CN
+Yuanwu,渊武,zh-CN
+Zani,赞妮,zh-CN
+Zenith Windblade,天渊风剑,zh-CN
+Zephyr Symphony,风乐交响,zh-CN
+Zhezhi,折枝,zh-CN

--- a/glossaries/wuthering-waves_zh-CN.csv
+++ b/glossaries/wuthering-waves_zh-CN.csv
@@ -416,7 +416,7 @@ Lumingloss,清音异响,zh-CN
 Luminous Hymn,和光回唱,zh-CN
 Lunar Cycle,月相流转,zh-CN
 Lunite,月相,zh-CN
-Lupa,露珀,zh-CN
+Lupa,露帕,zh-CN
 Lustrous Razor,浩境粼光,zh-CN
 Lustrous Tide,唤声涡纹,zh-CN
 Luuk Herssen,陆·赫斯,zh-CN

--- a/meta/index.json
+++ b/meta/index.json
@@ -27,5 +27,6 @@
     "stellar-blade-clothing",
     "Vocaloid",
     "access-control",
-    "hd2"
+    "hd2",
+    "wuthering-waves"
 ]

--- a/meta/wuthering-waves.json
+++ b/meta/wuthering-waves.json
@@ -1,0 +1,20 @@
+{
+  "id": "wuthering-waves",
+  "name": "Wuthering Waves",
+  "description": "English-to-Simplified Chinese glossary for Wuthering Waves game terms",
+  "author": "GlucoseA",
+  "glossary": "wuthering-waves",
+  "langs": [
+    "zh-CN"
+  ],
+  "i18ns": {
+    "zh-CN": {
+      "name": "鸣潮",
+      "description": "收录《鸣潮》游戏术语的中英对照翻译。"
+    },
+    "en": {
+      "name": "Wuthering Waves",
+      "description": "English-to-Simplified Chinese glossary for Wuthering Waves game terms."
+    }
+  }
+}


### PR DESCRIPTION
新增《鸣潮》（Wuthering Waves）英译简中术语库，并补充对应元数据。

本 PR：
- 新增 `wuthering-waves` 术语库
- 更新 `meta/index.json`
- 新增 `meta/wuthering-waves.json`
- 修正 `Lupa` 翻译为 `露帕`

该术语库主要覆盖《鸣潮》中的角色、地名、系统、武器及常见专有名词，用于提升相关内容翻译一致性。
