### PR TITLE
feat: 添加星际公民 Star Citizen 术语库 (4222 条)

### DIFF
--- a/glossaries/star-citizen_zh-CN.csv
+++ b/glossaries/star-citizen_zh-CN.csv
@@ -1,0 +1,4223 @@
+source,target,tgt_lng
+"Breakfast Dog","早餐热狗",zh-CN
+"Chairman's Club","礼宾俱乐部",zh-CN
+"Chili Dog","香辣热狗",zh-CN
+"Lost Squad","《失落中队》",zh-CN
+"Mōhio Museum","博识博物馆",zh-CN
+"Rachel Lester","雷切尔·莱斯特",zh-CN
+"""A Gift for Baba""","《给奶奶的礼物》",zh-CN
+"""Death From Above""","“死神天降”",zh-CN
+"""Fate""","“命运”",zh-CN
+"""Fly or Die""","“翱翔或者灭亡”",zh-CN
+"""Onto the Break""","《突破》",zh-CN
+"""Protection Provided""","“守护常在”",zh-CN
+"""The Starman's Farewell""","《太空兵的告别》",zh-CN
+"%ls","%ls",zh-CN
+"'One Meal' Nutrition Bar (Grilled Steak)","“壹餐”营养棒（烤牛排味）",zh-CN
+"'One Meal' Nutrition Bar (Roasted Chicken)","“壹餐”营养棒（烤鸡味）",zh-CN
+"'One Meal' Nutrition Bar (Spicy Salmon)","“壹餐”营养棒（辣鲑鱼味）",zh-CN
+"'YOUR GOODS IN GOOD HANDS'","'您的货物，有我保障'",zh-CN
+"(Apex)","（巅峰期）",zh-CN
+"-Delivering the Total Package-","-全套体贴货运服务-",zh-CN
+"100i","100i",zh-CN
+"125a","125a",zh-CN
+"135c","135c",zh-CN
+"250-E Laser Pointer","250-E 激光瞄准器",zh-CN
+"2nd Lieutenant","少尉",zh-CN
+"2Tuf","得劲儿",zh-CN
+"300i","300i",zh-CN
+"315p","315p",zh-CN
+"325a","325a",zh-CN
+"350r","350r",zh-CN
+"400i","400i",zh-CN
+"55-GR","55-GR",zh-CN
+"5CA Akura","5CA 阿库拉",zh-CN
+"5MA Chimalli","5MA 希马尔里",zh-CN
+"5SA Rhada","5SA 拉达",zh-CN
+"600i","600i",zh-CN
+"600i Executive Edition","600i 行政版",zh-CN
+"600i Exploration","600i 探索",zh-CN
+"600i flight jacket","600i 飞行夹克",zh-CN
+"600i Touring","600i 旅行",zh-CN
+"6CA Bila","6CA 比拉",zh-CN
+"6MA Kozane","6MA 科赞",zh-CN
+"6SA Arbiter","6SA 阿比特",zh-CN
+"78 Leonis","78 里奥斯",zh-CN
+"7CA Nargun","7CA 纳尔贡",zh-CN
+"7MA Lorica","7MA 洛丽卡",zh-CN
+"7SA Concord","7SA 康科德",zh-CN
+"85X","85X",zh-CN
+"88-BR","88-BR",zh-CN
+"88s","88 系列",zh-CN
+"890 Jump","890 跃动",zh-CN
+"987","987",zh-CN
+"99","99",zh-CN
+"A forager‘s guide to stanton","斯坦顿采集者指南",zh-CN
+"A Word from Our Sponsors","来自赞助商的话",zh-CN
+"A-Tek","爱踏客",zh-CN
+"A2 Hercules","大力神 A2",zh-CN
+"Aadya","阿迪亚",zh-CN
+"Aarin","阿林",zh-CN
+"Aaron Douze","亚伦·杜泽",zh-CN
+"Aaron Fring","艾伦·弗林",zh-CN
+"Aaron Frost","亚伦·弗罗斯特",zh-CN
+"Aaron Halo","亚伦环带",zh-CN
+"Aaron Riegert","亚伦·里格特",zh-CN
+"Aaron Schere","亚伦·谢尔",zh-CN
+"Aarthi","阿尔蒂",zh-CN
+"Abbie","阿比",zh-CN
+"Abby","艾比",zh-CN
+"Abe towers","亚伯塔",zh-CN
+"Abelina","阿贝琳娜",zh-CN
+"Aberdeen","阿伯丁",zh-CN
+"Aberdeen Hurston","阿伯丁·赫斯顿",zh-CN
+"Abernathy Interiors","阿伯纳西室内",zh-CN
+"Abetti","阿贝提",zh-CN
+"Abida","阿比达",zh-CN
+"Abigail","阿比盖尔",zh-CN
+"Able Baker Challenge","贝克征服挑战赛",zh-CN
+"Above & Beyond Insurance","至高超越保险",zh-CN
+"Abrar","阿布拉",zh-CN
+"Abril","阿布里尔",zh-CN
+"abs.","绝对值（速度/加速度/坐标）",zh-CN
+"Absolute Zero","绝对零度",zh-CN
+"Absorption","吸收率",zh-CN
+"AC","竞技场指挥官",zh-CN
+"Accelerated Mass Design","加速质量设计",zh-CN
+"Acceleration Limiter (Abs.)","加速度限制器（Abs.）",zh-CN
+"Access Card","访问卡",zh-CN
+"Ace Astrogation","王牌航天",zh-CN
+"Acheron","阿彻伦",zh-CN
+"Achilles Heavy Armor","阿喀琉斯重甲",zh-CN
+"Aciedo","亚希多",zh-CN
+"Aciedo CommRelay","亚希多通信",zh-CN
+"ACOM","ACOM",zh-CN
+"Acorn Limited","橡实有限公司",zh-CN
+"AcryliPlex Composite","亚克力络合物复合材料",zh-CN
+"Actively Incarcerated","在押人员",zh-CN
+"ActiveWear","主动装备",zh-CN
+"Adagio Holdings","阿德吉奥集团",zh-CN
+"Adel Fansekar","阿黛尔·范瑟卡",zh-CN
+"Adena Freund","阿登纳·弗洛恩德",zh-CN
+"Adir","阿迪尔",zh-CN
+"Adira Falls","阿迪拉瀑布",zh-CN
+"Adiva","阿迪瓦",zh-CN
+"Admin Center","行政中心",zh-CN
+"Admiral","上将",zh-CN
+"Admiral Ernst Bishop","恩斯特·毕晓普上将",zh-CN
+"Adorai Zahid","阿道莱·扎希德",zh-CN
+"ADP-mk4 Heavy Armor","ADP-mk4 重甲",zh-CN
+"AdrenaPen","肾上腺素笔",zh-CN
+"Adrift","逐流",zh-CN
+"Adroit","灵巧",zh-CN
+"advance mode","进阶模式",zh-CN
+"AdVance NanoGraph","先进纳米石墨",zh-CN
+"Advanced Combat Training Gauntlet","高级战斗训练高塔",zh-CN
+"Advanced Operative","进阶特派人员",zh-CN
+"Advanced Tracker License Certification","精英赏金猎人执照",zh-CN
+"Advocacy","督导局",zh-CN
+"Advocacy Archive","督导局档案",zh-CN
+"Adze","扁斧",zh-CN
+"Aegis","圣盾",zh-CN
+"Aegis Dynamics","圣盾动力",zh-CN
+"Aegis Reclaimer","圣盾 回收者",zh-CN
+"Aego","艾戈",zh-CN
+"Aero","气流",zh-CN
+"Aeroview Hangars","俯瞰机库",zh-CN
+"Afterburner","加力燃烧",zh-CN
+"Afterlife","来生",zh-CN
+"Agate Gray","玛瑙灰",zh-CN
+"Aggravated Assault","蓄意伤害",zh-CN
+"Aggravated Criminal Damage","严重刑事损害",zh-CN
+"Agitator","煽动者",zh-CN
+"Agni","阿格尼",zh-CN
+"Agricium","艾格瑞金属",zh-CN
+"Supplies","农业物资",zh-CN
+"Agricultural Goods","农业产品",zh-CN
+"Agricultural Supplies","农业用品",zh-CN
+"Agricultural Supply","农业用品",zh-CN
+"Agrippa","阿格里帕",zh-CN
+"Agrodolce Delight Kacho","阿格道奇欢喜卡乔面",zh-CN
+"Agure","阿古雷",zh-CN
+"Ahmanson","阿曼森",zh-CN
+"Ail'ka","艾尔'卡",zh-CN
+"Aim Mode (Pitch)","瞄准模式（俯仰）",zh-CN
+"Aim Mode (Yaw)","瞄准模式（偏转）",zh-CN
+"Aimi Zentani","爱米·森塔尼",zh-CN
+"AirFresh","新风",zh-CN
+"Aither","太空之神",zh-CN
+"Aiya/Touvoni","艾娅/图瓦尼",zh-CN
+"Ajax Security Uniform","阿贾克斯 安保制服",zh-CN
+"Akiko 'Jackal' Bazin","亚希子""豺狼""巴赞",zh-CN
+"Akiro Cluster","阿基洛小行星簇",zh-CN
+"Alan Nuevo","艾伦·奴厄弗",zh-CN
+"Alana Redmond","阿拉娜·瑞德曼德",zh-CN
+"Alatorres Forward Operating Base","阿拉特雷斯前线基地",zh-CN
+"Alban","奥尔本",zh-CN
+"Albert Triolo","阿尔伯塔·特奥罗",zh-CN
+"Aldus Carmichael","奥尔德斯·卡迈克尔",zh-CN
+"Alejo Brothers","阿莱霍兄弟",zh-CN
+"Alexei Dario","阿莱克西·达里奥",zh-CN
+"Algid","风寒",zh-CN
+"Ali Bojang","阿里·博扬",zh-CN
+"ALL IS NOT LOST(ALLIS)","为时未晚号",zh-CN
+"Allegiant","忠诚",zh-CN
+"Allegro","极速",zh-CN
+"Alliance Aid","援助联盟",zh-CN
+"Alliance Startech","联盟星际科技",zh-CN
+"Alloy","合金",zh-CN
+"Allstop","全面停滞",zh-CN
+"Aloprat","阿罗帕鼠",zh-CN
+"Alpha Wolf","头狼",zh-CN
+"Alpine Sunset","日落阿尔卑斯",zh-CN
+"Altimont","阿特蒙特",zh-CN
+"Altrucia","梸树",zh-CN
+"Altrucia Lacus","湖生梸树",zh-CN
+"Altruciatoxin","梸树毒",zh-CN
+"Aluminium","铝",zh-CN
+"Aluminum","铝",zh-CN
+"Amadi Murnau","阿马迪·穆尔瑙",zh-CN
+"Amalga Disposal Services","阿玛咖清理服务",zh-CN
+"Amare Jericho","阿玛雷·杰里科",zh-CN
+"Ambassador Flights","使节航空",zh-CN
+"Amber","琥珀",zh-CN
+"Amber Wave","琥珀纹",zh-CN
+"Ambit Coverall","境界 连体服",zh-CN
+"Ambitious Dream Station","雄心伟梦站",zh-CN
+"Ambrose","安布罗斯",zh-CN
+"Ambrus suit","安布罗斯",zh-CN
+"Amelia Boyd","阿米莉亚·博伊德",zh-CN
+"amenities","便利设施",zh-CN
+"Amiant Pod","石棉荚",zh-CN
+"Amiant Tree","石棉树/石棉荚",zh-CN
+"Plague","阿米什瘟疫",zh-CN
+"Amioshi Plague","阿米什瘟疫",zh-CN
+"Amir Tremaine","阿米尔`特雷曼",zh-CN
+"Ammo","弹药",zh-CN
+"Ammonia","氨",zh-CN
+"Amon & Reese Co.","亚蒙里斯公司",zh-CN
+"AMORI NOVAK!","阿莫里·诺瓦克",zh-CN
+"Ana","阿纳",zh-CN
+"Ana Armor","阿纳护甲",zh-CN
+"Anay Wolfe","恩雅·沃尔夫",zh-CN
+"Anchor","船锚",zh-CN
+"Andes Kello","安德斯·凯洛",zh-CN
+"Andre Novoselov","安德烈·诺沃肖洛夫",zh-CN
+"Angeli","安吉利",zh-CN
+"Angeli's Angels","安杰利天使",zh-CN
+"Animus Missile Launcher","敌意 导弹发射器",zh-CN
+"Annunciator Panels","报警面板",zh-CN
+"Anoushka O'Brian","阿努什卡·奥布赖恩",zh-CN
+"Anthony Tanaka","安东尼·田中",zh-CN
+"Anti-Hydrogen","反氢",zh-CN
+"Antium","安藤",zh-CN
+"Antium Armor","安腾护甲",zh-CN
+"Anvil","铁砧",zh-CN
+"Anvil Aerospace","铁砧航天",zh-CN
+"Anvil Ballista Dunestalker","铁砧航天 弩炮 沙丘追猎者",zh-CN
+"Anya Sugari","安雅·斯嘉丽",zh-CN
+"Anysta","安内斯塔",zh-CN
+"Anything you need, anywhere you need it.","尽你所需，达你所在。",zh-CN
+"Aopoa","奥波亚",zh-CN
+"AP-7 Concussion Grenade","AP-7 震荡手榴弹",zh-CN
+"Aparelli","阿帕雷利",zh-CN
+"Apex","顶尖",zh-CN
+"Apex Hall","峰顶展厅",zh-CN
+"Aphorite","紫钠水晶",zh-CN
+"Apocalypse Arms","启示录军备",zh-CN
+"Apollo","阿波罗",zh-CN
+"Apollo Medivac","阿波罗 医疗",zh-CN
+"Apollo Triage","阿波罗 分诊",zh-CN
+"Aponte Explorer","阿庞特探险家",zh-CN
+"Apoxygenite","氧石",zh-CN
+"APX Fire Extinguisher","APX 灭火器",zh-CN
+"Aqua","湖绿色",zh-CN
+"Aquamarine","海蓝色",zh-CN
+"Aranda","阿兰达",zh-CN
+"Aranda Crusader Edition","阿兰达 十字军版",zh-CN
+"Arbor","刀轴",zh-CN
+"ArcCorp","弧光星",zh-CN
+"ArcCorp Mining Area 045","弧光集团采矿站 045",zh-CN
+"ArcCorp Mining Area 048","弧光集团采矿站 048",zh-CN
+"ArcCorp Mining Area 056","弧光集团采矿站 056",zh-CN
+"ArcCorp Mining Area 061","弧光集团采矿站 061",zh-CN
+"ArcCorp Mining Area 141","弧光集团采矿站 141",zh-CN
+"ArcCorp Mining Area 157","弧光集团采矿站 157",zh-CN
+"ArcCorp Processing Center 115","弧光集团加工中心 115",zh-CN
+"ArcCorp Processing Center 123","弧光集团加工中心 123",zh-CN
+"Arccorp Tower","弧光塔",zh-CN
+"Archangel","大天使",zh-CN
+"Archangel Station","大天使空间站",zh-CN
+"Archibald Autumn","阿奇博尔德 秋橙色",zh-CN
+"Archibald Canvas","阿奇博尔德 帆布",zh-CN
+"Archibald Cinder","阿奇博尔德 煤灰色",zh-CN
+"Archibald Hearth","阿奇博尔德 哈斯色",zh-CN
+"Archibald Hurston","阿奇博尔德·赫斯顿",zh-CN
+"Archibald Smoke","阿奇博尔德 烟雾",zh-CN
+"Arclight Energy Pistol","弧光 能量手枪",zh-CN
+"Arctic","北极",zh-CN
+"Arctic Digital","极地迷彩",zh-CN
+"Arctic Storm","北境暴风",zh-CN
+"Arcus","弓形云",zh-CN
+"Ardell Hurston","阿德尔·赫斯顿",zh-CN
+"Arden-CL Backpack","阿尔登-CL 背包",zh-CN
+"Arden-SL","阿尔登-SL 护甲",zh-CN
+"Ardent","厄登",zh-CN
+"Ardor","炽热",zh-CN
+"Area18","18 区",zh-CN
+"Aremis","阿雷米斯",zh-CN
+"Aremis Post","阿雷米斯通讯",zh-CN
+"Ares Inferno","战神 地狱火",zh-CN
+"Ares Ion","战神 离子光",zh-CN
+"ARES STAR FIGHTER","战神 星际战斗机",zh-CN
+"Argo","南船座",zh-CN
+"Argo Astronautics","南船座宇航",zh-CN
+"Argon","氩",zh-CN
+"Argos","阿尔格斯",zh-CN
+"Argul Dawn","阿古尔黎明",zh-CN
+"Argus","阿古斯",zh-CN
+"Ari Barber","阿里·巴伯",zh-CN
+"Aria Reilly","阿丽亚·莱利",zh-CN
+"Arial","艾瑞尔",zh-CN
+"Ariel","艾瑞尔",zh-CN
+"Aril","伪壳",zh-CN
+"Aris Walesko","阿瑞斯·威尔士科",zh-CN
+"Arjun Walzer","阿俊·瓦泽",zh-CN
+"Ark Archive","方舟档案",zh-CN
+"Arlington gang","阿灵顿帮",zh-CN
+"Arlow Gellis","阿洛·盖利什",zh-CN
+"Armaan Ascher","阿尔曼·阿舍尔",zh-CN
+"Armada","舰队",zh-CN
+"ArmaMod","武改厂",zh-CN
+"Armillaria","蜜环菌",zh-CN
+"Armistice Day","停战日",zh-CN
+"Armistice Violation","违反禁火协议",zh-CN
+"Armitage","阿米塔奇",zh-CN
+"Armor","护甲",zh-CN
+"Armored Flight Suit","装甲飞行服",zh-CN
+"Arms","臂甲",zh-CN
+"Arrastra","阿拉斯塔",zh-CN
+"Arrester","逮捕者",zh-CN
+"Arrow","箭矢",zh-CN
+"Arrow & Ross Weapon Systems","艾罗&罗斯武器公司",zh-CN
+"Arrowhead Sniper Rifle","箭头 能量狙击枪",zh-CN
+"Arroyo","赭红",zh-CN
+"Arsenic","砷",zh-CN
+"Art Cormack","阿特·科马克",zh-CN
+"Artificial","人造行星",zh-CN
+"Artimex","阿蒂麦斯",zh-CN
+"Aruto Divani","爱洛朵·迪瓦尼",zh-CN
+"Ascension","升天",zh-CN
+"Ascension Astro","上升航天",zh-CN
+"Ascension Astro Soloshield","上升航天 单兵护盾",zh-CN
+"ASD","联科发",zh-CN
+"Asgard","阿斯加德",zh-CN
+"Ashburn Channel","阿什本通道",zh-CN
+"Ashburn Channel Aid Shelter","阿什本通道援助避难所",zh-CN
+"Ashfall","落尘",zh-CN
+"Asiatica","泛亚组织",zh-CN
+"Asif Reader","阿西夫·利德尔",zh-CN
+"Aslarite","阿斯莱晶体",zh-CN
+"Aspect Ratio","宽高比",zh-CN
+"AspectRatioLibrary","宽高比库",zh-CN
+"Aspire Grand","志远大厦",zh-CN
+"Aspire livery","志远涂装",zh-CN
+"Aspis","重盾",zh-CN
+"Assailant","攻击者",zh-CN
+"Assault","突袭",zh-CN
+"Assaulting Security Personnel","袭击警务人员",zh-CN
+"Assistant Director","副局长",zh-CN
+"Assistant Section Chief","助理地区厅长",zh-CN
+"Assistant Special Agent-in-Charge","助理特别探督",zh-CN
+"Associate","助理",zh-CN
+"Associate Contractor","副承包商",zh-CN
+"Associated Science & Development","联合科学与开发公司",zh-CN
+"Astatine","砹",zh-CN
+"Aster","紫苑",zh-CN
+"Aster Remmington","阿斯特·雷明顿",zh-CN
+"Astley Black","阿斯特利 黑色",zh-CN
+"Astley Sunset","阿斯特利 日落色",zh-CN
+"Aston Ridge","阿斯顿岭",zh-CN
+"Aston Ridge Aid Shelter","阿斯顿岭援助避难所",zh-CN
+"Astor's Clearing","阿斯特空地",zh-CN
+"Astral Plane","《星界飞机》",zh-CN
+"Astrid Messer","阿斯特里德·梅塞尔",zh-CN
+"Astro Arena","天文竞技场",zh-CN
+"Astro Armada","天文舰队",zh-CN
+"AstroArmada","天文舰队",zh-CN
+"Astromedics: Back from the Brink","太空医疗：起死回生",zh-CN
+"Asura","阿修罗",zh-CN
+"Atavi","阿塔维",zh-CN
+"Ati","埃蒂",zh-CN
+"Atlas","擎天巨神",zh-CN
+"Atlas Platform","阿特拉斯平台",zh-CN
+"Atlasium","巨神合金",zh-CN
+"ATLS","ATLS",zh-CN
+"Atrophic","肌肉无力",zh-CN
+"Attachments","附件",zh-CN
+"Attempted Escape from Custody","逃离监禁未遂",zh-CN
+"Attempted Homicide","谋杀未遂",zh-CN
+"Attrition","磨损",zh-CN
+"ATVS","ATVS  Repeaterx",zh-CN
+"Atzkav Sniper Rifle","阿兹卡夫 狙击步枪",zh-CN
+"Auditor Pants","审计员 长裤",zh-CN
+"Auditor Shirt Covalex Edition","审计员 衬衫 科瓦莱什版",zh-CN
+"Auditor Shirt Crusader Edition","审计员 衬衫 十字军版",zh-CN
+"Aufeis","积冰",zh-CN
+"August Dunlow","奥古斯特·顿洛",zh-CN
+"August Dunlow Spaceport","奥古斯特·顿洛 空港",zh-CN
+"Auris","奥瑞斯",zh-CN
+"Aurora","极光",zh-CN
+"Aurora CL","极光 CL",zh-CN
+"Aurora ES","极光 ES",zh-CN
+"Aurora LN","极光 LN",zh-CN
+"Aurora LX","极光 LX",zh-CN
+"Aurora MR","极光 MR",zh-CN
+"Auspicious Red Ram","吉祥红公羊",zh-CN
+"Autocannon","自动加农炮",zh-CN
+"AutoDoc","智能医生",zh-CN
+"autopilot","自动驾驶",zh-CN
+"Auxiliary Staff","后备人士",zh-CN
+"Ava Skenning","艾娃·斯肯宁",zh-CN
+"Avalanche","雪崩",zh-CN
+"Avalos Scout","阿瓦洛斯侦察兵",zh-CN
+"AvantX","前卫X",zh-CN
+"Avasi Scandal","阿瓦西丑闻",zh-CN
+"Avel Gedima","阿维尔·吉迪玛",zh-CN
+"Avenger","复仇者",zh-CN
+"Avenger Stalker","复仇者 追猎",zh-CN
+"Avenger Titan","复仇者 泰坦",zh-CN
+"Avenger Titan Renegade","复仇者 泰坦变节者",zh-CN
+"Avenger Warlock","复仇者 术士",zh-CN
+"Aves","飞鸟",zh-CN
+"Avivar Alliance","火爆联盟",zh-CN
+"Avocado and Corn Sandwich","鳄梨玉米三明治",zh-CN
+"Awaken","唤醒",zh-CN
+"Axel Adamson","阿克塞尔·亚当森",zh-CN
+"Axiom","公理",zh-CN
+"Ayana Reyes","阿亚娜·雷耶斯",zh-CN
+"Aydo","艾多",zh-CN
+"Ayr'ka","艾尔'卡",zh-CN
+"Ayre Semisonic","艾尔半音速",zh-CN
+"Azrael","死亡天使",zh-CN
+"Aztalan","阿兹塔兰",zh-CN
+"B.D.L.","血药浓度",zh-CN
+"Baas","巴斯",zh-CN
+"Bacchus","巴克斯",zh-CN
+"Bacchus Flotilla","巴克斯船团",zh-CN
+"Backpack","背包",zh-CN
+"Backpack Compatibility","可挂载背包",zh-CN
+"Backpacks:","可挂载背包类型：",zh-CN
+"Bacon Club Sandwich","培根总汇三明治",zh-CN
+"Badami","【暂定】巴达米",zh-CN
+"Badger Bad","恶獾公司",zh-CN
+"Badlands","荒地",zh-CN
+"Baer Comet","巴尔彗星",zh-CN
+"Bagamba Brockway","巴甘巴·布洛克威",zh-CN
+"Baijini Point","拜基尼空间站",zh-CN
+"Baker","贝克",zh-CN
+"Balaclava and Goggles","头套及目镜",zh-CN
+"Balandin","巴兰丁",zh-CN
+"Balboa","巴波亚",zh-CN
+"Balefire","野火",zh-CN
+"Baler","捆扎",zh-CN
+"Ballista","弩炮",zh-CN
+"Ballistic","实弹",zh-CN
+"Balor HCH","巴洛安全",zh-CN
+"Balthazar","巴尔萨泽",zh-CN
+"Bamoty","巴莫蒂",zh-CN
+"Banco Foxwell","班克·福克斯韦尔",zh-CN
+"Banded Fessle","蓝带食人鱼",zh-CN
+"Banshee","女妖",zh-CN
+"Bantam","矮脚鸡",zh-CN
+"Banu","巴努",zh-CN
+"BANU DEFENDER","巴努防卫者",zh-CN
+"Banu Firesale","巴努贱卖",zh-CN
+"Banu Protectorate","巴努保护国",zh-CN
+"Banu souli","巴努公会",zh-CN
+"Bao Ingram","鲍尔·英格拉姆",zh-CN
+"Bao Yun","云保",zh-CN
+"Barbican","外堡",zh-CN
+"Barrel","枪管",zh-CN
+"Barrel Palm","桶形棕榈",zh-CN
+"Barrymore","巴里摩尔",zh-CN
+"Barter Barnhill","巴斯特·巴希尔",zh-CN
+"Basara","婆娑罗",zh-CN
+"Basilisk","蛇怪公司",zh-CN
+"Bass' Caves of Terra","《巴斯：泰拉之岩洞》",zh-CN
+"Bastien Nemitz","巴斯蒂安·涅米兹",zh-CN
+"Bastion","堡垒",zh-CN
+"Battery","电池",zh-CN
+"Battery (First Degree)","袭击（一级）",zh-CN
+"Battery (Second Degree)","袭击（二级）",zh-CN
+"Bautista","包蒂斯塔",zh-CN
+"Baylor Ward","贝勒·沃德",zh-CN
+"Beacon","信标",zh-CN
+"Beacon Rust Society Undersuit","信标基底服-锈红协会版",zh-CN
+"Beacon Undersuit","信标基底服",zh-CN
+"Beam","光束/光束炮",zh-CN
+"beat","拍",zh-CN
+"Beautiful Glen Station","美丽峡谷站",zh-CN
+"Because staying healthy should be easy","保持健康 就该如此容易",zh-CN
+"Beck Russum","贝克·罗森",zh-CN
+"BEHR PK-1 Sweeper","贝林 PK-1 清道夫",zh-CN
+"Behring","贝林",zh-CN
+"Behring consortium","贝林财团",zh-CN
+"Beijing Reactor and Enrichment Company","北京反应堆与浓缩设备公司",zh-CN
+"Bello Shirt","贝洛衬衫",zh-CN
+"Bello T-Shirt Navy","贝洛T恤 海军蓝",zh-CN
+"Ben Totland","本·托兰德",zh-CN
+"Benaderet Dress","本德雷 长裙",zh-CN
+"Bendix","奔德士",zh-CN
+"Bengal","孟加拉",zh-CN
+"Benicio Lewis, Jr.","小贝尼西奥·刘易斯",zh-CN
+"Bennet Hogg","本内特·霍格",zh-CN
+"Benson Mining Outpost","本森采矿前哨站",zh-CN
+"Beraber Fir","冰蓝枞",zh-CN
+"Beradom","冰蓝珀",zh-CN
+"Berian","布内恩",zh-CN
+"Beringer Brothers","毕林尔兄弟",zh-CN
+"Bernard Pak","伯纳德·帕克",zh-CN
+"Berry Blend Smoothie","浆果冰沙",zh-CN
+"Berserker","狂战士",zh-CN
+"beryl","绿柱石",zh-CN
+"Bespoke","定制",zh-CN
+"best in show","展会最佳",zh-CN
+"Better Today Act","美好今日法案",zh-CN
+"Bevic Convention Center","贝维克会展中心",zh-CN
+"Bevic Group","贝维克集团",zh-CN
+"Bexalite","贝沙电气石",zh-CN
+"Bezdova","别兹多娃",zh-CN
+"Bibiana","毕碧安娜",zh-CN
+"Big Barrys","大巴尼",zh-CN
+"Big Benny's","大本尼",zh-CN
+"Big Benny's T-shirt","大本尼 T恤",zh-CN
+"biometrics","生物特征证件",zh-CN
+"Bioplastic","生物塑料",zh-CN
+"BiotiCorp","生物技术公司",zh-CN
+"Bipasha Zhu","碧帕莎·朱",zh-CN
+"Birthplace of Vortex Thorson","""涡旋""索森的出生地",zh-CN
+"Bisbee","【暂定】比斯比",zh-CN
+"Bit Zeros","零比特",zh-CN
+"BlacJac Security","黑杰克安保",zh-CN
+"Black","黑色",zh-CN
+"Black Bean Ramian","黑豆拉面",zh-CN
+"Black Cherry","黑樱桃",zh-CN
+"Black Heron","黑鹭",zh-CN
+"Black Hole","黑洞",zh-CN
+"Black Mountain Sujin Tea (Medium Blend)","黑山苏津茶（中度调和）",zh-CN
+"Black Mountain Sujin Tea (Mild)","黑山苏津茶（温和）",zh-CN
+"Black Mountain Sujin Tea (Rich)","黑山苏津茶（丰厚）",zh-CN
+"Black Op","黑色行动",zh-CN
+"Black Rose","黑玫瑰",zh-CN
+"Blackguard","恶棍",zh-CN
+"Blacklist","黑名单",zh-CN
+"Blade","刀锋",zh-CN
+"Blast Chill","爆寒",zh-CN
+"Bleeding","失血",zh-CN
+"Blitz","闪电赛",zh-CN
+"Blizzard","暴雪",zh-CN
+"Bloc","集团",zh-CN
+"Blockade Runner","封锁突破者",zh-CN
+"Bloodline","血色迷彩",zh-CN
+"Bloom","盛放星",zh-CN
+"Blue","蓝色",zh-CN
+"Blue Ametrine","靛黄晶",zh-CN
+"blue bilva","蓝木橘",zh-CN
+"Blue Triangle","蓝三角",zh-CN
+"Blue Triangle Inc.","蓝三角股份有限公司",zh-CN
+"Bluemoon Fungus","蓝月菌",zh-CN
+"Blueshift","蓝移",zh-CN
+"Blueshift Livery","蓝移涂装",zh-CN
+"Bo-Go (Angeli Original)","宝格（安吉利原味）",zh-CN
+"Bo-Go (Crawdad)","宝格（安吉利虾）",zh-CN
+"Bo-Go (Hot and Sweet)","宝格（甜辣味）",zh-CN
+"Bo-Go (Langoustine and Lamb)","宝格（海螯虾和羔羊肉）",zh-CN
+"Bokto","授卫",zh-CN
+"Bolide","火流星",zh-CN
+"Bologna Sandwich","博洛尼亚三明治",zh-CN
+"Bolon","伯龙",zh-CN
+"Bolt","雷电",zh-CN
+"Bomber","轰炸",zh-CN
+"Bombora","湍流星",zh-CN
+"boneyard","骸骨迷彩",zh-CN
+"Bonito","鲣鱼",zh-CN
+"boomtube","爆破筒",zh-CN
+"BOOST","助推",zh-CN
+"BoostPen","兴奋笔",zh-CN
+"Boot","靴子",zh-CN
+"BOotycall","打炮热线",zh-CN
+"Borase","波射石",zh-CN
+"Bordello","伯德劳",zh-CN
+"Borea","博瑞雅",zh-CN
+"Boreal","北风",zh-CN
+"Borehole Station","钻孔站",zh-CN
+"Borisov's Herd","鲍里索夫的牧群",zh-CN
+"Boro","博罗",zh-CN
+"Botero Group","博特罗集团",zh-CN
+"Bountiful Harvest","丰收种植站",zh-CN
+"Bountiful Harvest Hydroponics","丰收水培种植站",zh-CN
+"Bounty Hunter Guild","赏金猎人公会",zh-CN
+"Bounty Hunters Guild","赏金猎人公会",zh-CN
+"BR-2 Ballistic Shotgun","BR-2 实弹霰弹枪",zh-CN
+"Brace","支撑",zh-CN
+"Bracer","寒索",zh-CN
+"Bracewell","布雷塞韦尔",zh-CN
+"Braden Corchado","布雷登·科查多",zh-CN
+"Braga malt/Snazzle","巴尔加麦芽/雪奈滋",zh-CN
+"Branaugh","布兰诺",zh-CN
+"Brandishing a Weapon","非法展示武器",zh-CN
+"Brandon Lazarides","布兰登·拉扎里德斯",zh-CN
+"Brawler Medium Armor","争吵者中型护甲",zh-CN
+"Breakfast Dog","早餐热狗",zh-CN
+"Breakneck","折颈",zh-CN
+"Bree Kuznetsov","布里·库兹涅佐夫",zh-CN
+"Bremen","布莱梅",zh-CN
+"Bremen Mills","不莱梅磨坊",zh-CN
+"Brentworth Care Center","布伦特沃斯医护中心",zh-CN
+"Breton","布列塔尼",zh-CN
+"Brigadier General","准将",zh-CN
+"Brightspot Flashlight","光点 战术手电",zh-CN
+"Brio's Breaker Yard","布里奥的拆船场",zh-CN
+"Broad & Rabiee","布拉德&拉比",zh-CN
+"Brown","棕色",zh-CN
+"BrownHex","六角棕",zh-CN
+"Bruce Amodeo","布鲁斯·阿莫多",zh-CN
+"Bruce's Bounty","布鲁斯的馈赠",zh-CN
+"Brushwood Platform","布拉什伍德平台",zh-CN
+"BRVS","BRVS Ballistic Repeater",zh-CN
+"Bry Hojika","布赖·霍吉卡",zh-CN
+"Bryan Shakir","布莱恩·沙基尔",zh-CN
+"Bryce Balewa","布莱斯·巴列瓦",zh-CN
+"Buccaneer","掠夺者",zh-CN
+"Buckets","水桶",zh-CN
+"Bud's Growery","巴德种植园",zh-CN
+"Bueno Ravine","布埃诺峡谷",zh-CN
+"Builders of Tomorrow","砌筑未来之士",zh-CN
+"Bulwark","堡垒",zh-CN
+"Bureau of Resource Management","资源管理局",zh-CN
+"Burgundy Paisley Bandana","勃艮第佩斯利头巾",zh-CN
+"Burner Zeke","伯纳尔·齐克",zh-CN
+"Burst","爆发",zh-CN
+"burst transmitter","突发式发射器",zh-CN
+"Business District","商业区",zh-CN
+"Buster's Chocolate Bar","巴斯特巧克力棒",zh-CN
+"C-788","C-788 Ballistic Autocannon",zh-CN
+"C-810","C-810 Ballistic Cannon",zh-CN
+"C-912","C-912 Ballistic Cannon",zh-CN
+"C-series","C-系列",zh-CN
+"C2 Hercules","大力神 C2",zh-CN
+"C54  SMG","C54 微型冲锋枪",zh-CN
+"C8 PISCES","C8 双鱼座",zh-CN
+"C8R Pisces Rescue","C8R 双鱼座 救护",zh-CN
+"C8X","C8X",zh-CN
+"Cadmium Allinide","亚胺镉",zh-CN
+"Café Musain","缪尚咖啡馆",zh-CN
+"Caiman","鳄鱼",zh-CN
+"Cal-O-Meal","卡欧膳食",zh-CN
+"Calah Hurston","卡拉·赫斯顿",zh-CN
+"Calamity","灾星",zh-CN
+"Caldera","火山臼",zh-CN
+"Calhoun Pass Emergency Shelter","卡洪山口紧急避难所",zh-CN
+"Caliban","卡利班",zh-CN
+"Calico","棉布",zh-CN
+"Calliope","卡利俄佩",zh-CN
+"Cally Stroble","卡莉·斯特罗布",zh-CN
+"Calva","颅盖",zh-CN
+"Cambio SRT","转化宝 打捞修复工具",zh-CN
+"Cambio-Lite","转化宝-Lite",zh-CN
+"Cambrio","转化宝",zh-CN
+"Camera POV","【待定】摄像机视角",zh-CN
+"Camion","卡米翁",zh-CN
+"Campo","坎波",zh-CN
+"Candy","糖果",zh-CN
+"cannon","加农炮",zh-CN
+"Cano","卡诺",zh-CN
+"Canoiodide","卡诺碘",zh-CN
+"Canuto","箭筒",zh-CN
+"cap","发",zh-CN
+"Capital Ship","主力舰",zh-CN
+"Capsulo","卡普苏洛",zh-CN
+"Captain","上校",zh-CN
+"Captain General","元帅",zh-CN
+"Captain Medcalf","麦德卡夫船长",zh-CN
+"Captain Omar Singh","奥马尔·辛格船长",zh-CN
+"Captain's Mix Sandwich","舰长的混搭三明治",zh-CN
+"Captor","劫持者",zh-CN
+"carafi","卡拉菲能量块",zh-CN
+"Carafi Cube","卡拉菲能量块",zh-CN
+"Carbide","碳钨",zh-CN
+"Carbon","碳黑",zh-CN
+"Carbon Planet","碳行星",zh-CN
+"Carbon-Silk","碳绸",zh-CN
+"Cardona","卡多纳",zh-CN
+"Caret","【暂定】卡雷特",zh-CN
+"Carey Sun","孙凯莉",zh-CN
+"Cargo","货运",zh-CN
+"Cargo Deck","货运甲板",zh-CN
+"Cargo Handler Assiciation","货物装卸协会",zh-CN
+"Cargo Hat","货物帽",zh-CN
+"Cargo Services","货运服务",zh-CN
+"Cargolympics","物流奥林匹克",zh-CN
+"Carinite","科力晶",zh-CN
+"Carnifex Armor","刽子手",zh-CN
+"Carnita-ritas Burrito","卡尼塔斯猪肉卷饼",zh-CN
+"Carnival livery","狂欢节涂装",zh-CN
+"Carolyn 'Vortex' Thorson","卡罗琳·'涡旋'·索森",zh-CN
+"Carrack","克拉克",zh-CN
+"Carrack T-shirt","克拉克T恤",zh-CN
+"Carragio Jacket","卡拉乔洛 夹克",zh-CN
+"Carrier-based Bomber","舰载轰炸机",zh-CN
+"Carrion","腐尸",zh-CN
+"Carryall","储物包",zh-CN
+"Carrying Capacity","储物空间",zh-CN
+"Carrying Capacity:","储物空间：",zh-CN
+"Casaba Outlet","卡莎巴服装店",zh-CN
+"Cascade","喷流",zh-CN
+"Cascom","卡斯康",zh-CN
+"Cassa","卡萨",zh-CN
+"Casse Aerospace","卡斯航空航天",zh-CN
+"Cassel","卡塞尔",zh-CN
+"Cassellitos","卡塞利托斯",zh-CN
+"Castillo","卡斯蒂罗",zh-CN
+"Castor","卡斯托",zh-CN
+"Castra","卡斯塔",zh-CN
+"Cataby","卡塔比",zh-CN
+"Caterpillar","毛虫",zh-CN
+"Cathcart","卡思卡特",zh-CN
+"Caudillo","考迪罗",zh-CN
+"CBD","CBD",zh-CN
+"CC's Conversions","CC 改造",zh-CN
+"CC:","抄送：",zh-CN
+"CDF","民事防御部队",zh-CN
+"CDS QuickCade","CDS 快搭墙",zh-CN
+"CDS QuickCade Ammo","CDS 快搭墙能源",zh-CN
+"Celestial","天体",zh-CN
+"Cellin","赛琳",zh-CN
+"Cellin Center HydroFarm","赛琳中央水培农场",zh-CN
+"Cellin's Peak","赛琳峰",zh-CN
+"Cenote Concern","天然井公司",zh-CN
+"Centauri","半人马",zh-CN
+"Centennial Bloom","世纪花",zh-CN
+"center cap","中央盖板",zh-CN
+"CenterMass","核心区域",zh-CN
+"Central Core Bank","中央核心银行",zh-CN
+"Central Tower livery","中央大厦涂装",zh-CN
+"Centralist Party","集权党",zh-CN
+"Centurion","百夫长",zh-CN
+"Ceprozin","噻普洛嗪",zh-CN
+"Cerberus","地狱犬",zh-CN
+"Cereus Rubra (Kavische)","红顶仙人掌（卡维斯彻）",zh-CN
+"Cerrado","赛拉多",zh-CN
+"Cestulus","塞特拉斯",zh-CN
+"Ch.iing","驰银",zh-CN
+"Chad Fawley","查德·弗利",zh-CN
+"Chaff","箔条电磁干扰弹",zh-CN
+"Chamar","查马尔",zh-CN
+"Chan-Eisen Field","陈-艾森力场",zh-CN
+"Charcoal","炭灰色",zh-CN
+"Charge Window Level","充能水平",zh-CN
+"Charger","战马",zh-CN
+"Charon","夏戎",zh-CN
+"Chase Hewitt","蔡斯·休伊特",zh-CN
+"Checkmate","死局空间站",zh-CN
+"Cheddar Ham Burrito","切达奶酪火腿卷饼",zh-CN
+"Cheese and Tomato Pizza (Slice)","一片芝士番茄比萨",zh-CN
+"Cherie","切丽",zh-CN
+"Chernykh","切尔尼克",zh-CN
+"Cherry","樱桃红",zh-CN
+"Cherry Blossom","樱花",zh-CN
+"Chesterfield Hurston","切斯特菲尔德·赫斯顿",zh-CN
+"Chestnut","栗色",zh-CN
+"Chicken Wham","鸡肉温姆堡",zh-CN
+"Chief Petty Officer","上士",zh-CN
+"Chile Birria Burrito","辛辣比利亚羊肉卷饼",zh-CN
+"Chili Dog","香辣热狗",zh-CN
+"Chili Mac Combat Ration","辣通心粉战斗口粮",zh-CN
+"Chill Max","寒意满满",zh-CN
+"Chimera Communications","奇美拉通讯",zh-CN
+"Chiron","喀戎",zh-CN
+"chlorine","氯气",zh-CN
+"Chokehold","扼喉",zh-CN
+"Chris Roberts","克里斯·罗伯茨",zh-CN
+"Christina Clark","克里斯蒂娜·克拉克",zh-CN
+"Chrome","铬黄（存疑）",zh-CN
+"Chrome Dome","铬金圆顶",zh-CN
+"Chronos","克洛诺斯",zh-CN
+"Chui’ā","翠雅",zh-CN
+"CIG","云间帝国游戏",zh-CN
+"Cinder","煤灰",zh-CN
+"Cirrus","卷云",zh-CN
+"Citadel","要塞",zh-CN
+"Citizen's Clean World Alliance","公民清洁世界联盟",zh-CN
+"Citizen's Pride","公民之傲",zh-CN
+"Citizens","公民",zh-CN
+"Citizens for Prosperity","繁荣公民",zh-CN
+"Citizens for Pyro","派罗公民",zh-CN
+"Citron","香橼 （纯色黄）",zh-CN
+"Citrus Beef Burrito","柑橘牛肉卷饼",zh-CN
+"Citrus Blend Smoothie","柑橘冰沙",zh-CN
+"Citrus Rush Smoothie","柑橘冲击冰沙",zh-CN
+"City Lights","城市之光",zh-CN
+"Cityflight Transit","市航交通",zh-CN
+"Civilian","平民",zh-CN
+"Civilian Close Support","民用后勤",zh-CN
+"Civilian Defense Force","民事防御部队",zh-CN
+"CK13-GID Seed Blend","CK13-GID 杂交种子",zh-CN
+"Clan Theory","《氏族理论》",zh-CN
+"Clara Douglas","克拉拉·道格拉斯",zh-CN
+"Clarence Hatfield","克拉伦斯·哈特菲尔德",zh-CN
+"Clark Defense Systems","卡拉克防御系统",zh-CN
+"Clarke Committee","卡拉克委员会",zh-CN
+"Clarkson","克拉克森",zh-CN
+"Clash","冲突",zh-CN
+"Class","分类",zh-CN
+"Class 2b Mount","2b 级武器挂点",zh-CN
+"Class A","A 级",zh-CN
+"Class B","B 级",zh-CN
+"Class C","C 级",zh-CN
+"Classic Dog","经典热狗",zh-CN
+"Claudia Besser","克劳迪娅·贝瑟",zh-CN
+"Claw Salamanders","爪蜥帮",zh-CN
+"Clean and Clear Work Apron","整洁明了 工作围裙",zh-CN
+"Clean Shot","清镜频道",zh-CN
+"Clear View Emergency Shelter","清晰视界紧急避难所",zh-CN
+"Cleaver","切割者",zh-CN
+"Clement Redfield","克莱门特·雷德菲尔德",zh-CN
+"Clempt","克兰朋",zh-CN
+"Cleo","克利奥",zh-CN
+"Cliffback","崖归",zh-CN
+"Cliffhanger","悬念",zh-CN
+"Cliffhanger Livery","悬念涂装",zh-CN
+"Clifton Brothers","克利夫顿兄弟",zh-CN
+"Clinic","诊所",zh-CN
+"Clio","克利俄",zh-CN
+"Clip","打手",zh-CN
+"Clipper","快帆",zh-CN
+"ClipVest","回形针上装",zh-CN
+"Cloak","斗篷",zh-CN
+"Clor Vee","克洛·维",zh-CN
+"Clothing","服装",zh-CN
+"Cloud City","云之城",zh-CN
+"Cloudburst","云爆",zh-CN
+"Cloudrest Retreat","云歇避风港",zh-CN
+"CloudSprint","柔云疾跑",zh-CN
+"Cloudview Center","云景中心",zh-CN
+"Clovus Darneely","克洛夫斯·达尼利",zh-CN
+"Cluster","小行星群",zh-CN
+"Cluster Factor","【待定】富集系数",zh-CN
+"Cluster Modifier","最佳充能窗口大小",zh-CN
+"coal","煤",zh-CN
+"Coalfire","煤火",zh-CN
+"Coat","外套",zh-CN
+"Cobalt","钴蓝色",zh-CN
+"Coconut Curry Kacho","椰子咖喱卡乔面",zh-CN
+"Coda","终曲",zh-CN
+"Coda Ballistic Pistol","终曲 实弹手枪",zh-CN
+"Code Blue Apparel","蓝色编码服装",zh-CN
+"Cody","科迪",zh-CN
+"Coffee (Mug)","咖啡（马克杯装）",zh-CN
+"Cognitive Boosting","认知增强",zh-CN
+"Cognitive Impairing","认知障碍",zh-CN
+"Col","山口",zh-CN
+"Cold Snap","寒流",zh-CN
+"Cold Surge","寒潮",zh-CN
+"Coloma","科洛马",zh-CN
+"Colonel","上校",zh-CN
+"Colossus","巨像",zh-CN
+"Combat Gauntlet","战斗试炼",zh-CN
+"Combat Readiness Uniform","狗斗准备服",zh-CN
+"ComfortAir","舒气",zh-CN
+"Comm Arrays","通信阵列",zh-CN
+"Commander","中校",zh-CN
+"Commander Herdsman","赫斯曼指挥官",zh-CN
+"CommArray","通信阵列",zh-CN
+"CommArray Protection Act","《通信阵列保护法案》",zh-CN
+"Committee on Economic Development","经济发展委员会",zh-CN
+"Committee on Interstellar Commerce","星际商业委员会",zh-CN
+"CommLink","【待定】通讯连接",zh-CN
+"Commodore","准将",zh-CN
+"Common Law","普通法",zh-CN
+"comp-board","计算板",zh-CN
+"Compboard","电路板",zh-CN
+"Compensator","枪口补偿器",zh-CN
+"Comstab (Command Stability)","指令增稳/循迹控制",zh-CN
+"Concept","概念",zh-CN
+"Concerned Citizens Foundation","公民关怀基金会",zh-CN
+"Condi Hillard","康蒂·希拉德",zh-CN
+"Congress","议会",zh-CN
+"Congress Now","国会现在",zh-CN
+"Conifer","针叶树",zh-CN
+"Connelly Reeves","康奈利·里夫斯将军",zh-CN
+"Conner's Beard Moss","康纳胡须地衣",zh-CN
+"Conni Ling","康妮·玲",zh-CN
+"Connor's","康纳小屋",zh-CN
+"Conscientious Objects","尽职之物",zh-CN
+"Consolidated Outland","联合外域",zh-CN
+"Constantine Hurston","康斯坦丁·赫斯顿",zh-CN
+"CONSTELLATION","星座",zh-CN
+"Constellation Andromeda","仙女座",zh-CN
+"Constellation Aquila","天鹰座",zh-CN
+"Constellation Phoenix","凤凰座",zh-CN
+"Constellation Phoenix Emerald","凤凰座 翡翠绿",zh-CN
+"Constellation Taurus","金牛座",zh-CN
+"Consumer Goods","生活用品",zh-CN
+"contract","合约",zh-CN
+"Contractor","承包商",zh-CN
+"CONTRACTOR AFFILIATION","承包商从属",zh-CN
+"Controlled Substance","管控物",zh-CN
+"Conva Maynard","康瓦·梅纳德",zh-CN
+"Cool Core","冷却核心",zh-CN
+"COOL-WEV","酷网",zh-CN
+"Copernicus","哥白尼",zh-CN
+"Copper","铜",zh-CN
+"Copperhead","铜斑蛇",zh-CN
+"Coramor","科拉爱人节",zh-CN
+"Corath’thal","科拉瑟·塔尔",zh-CN
+"Corazon Tan","科拉松·谭",zh-CN
+"Corbel","拱石",zh-CN
+"Corbin Cassady","科尔宾·卡萨迪",zh-CN
+"Corbyn Salehi","科尔宾·萨利希",zh-CN
+"Cordimon","科尔迪曼",zh-CN
+"Cordry's","科德里小铺",zh-CN
+"Core","胸甲",zh-CN
+"Core Compatibility","可适配胸甲类型",zh-CN
+"Corel","科内尔",zh-CN
+"Coreless Planet","无核行星",zh-CN
+"Corilla","科里拉",zh-CN
+"Corin","柯林",zh-CN
+"Coriolus Initiative","克里奥鲁斯倡议",zh-CN
+"Cormack Method","科马克加工法",zh-CN
+"Cornerstone Developments","基石开发公司",zh-CN
+"Cornerstone Developments’ Guide To Maintenance","基石开发公司维护指南",zh-CN
+"Corporal","下士",zh-CN
+"Corsair","海盗船",zh-CN
+"Corsti","柯蒂斯",zh-CN
+"Cort Legrande","柯尔特·莱格朗德",zh-CN
+"CorticoPen","皮质醇笔",zh-CN
+"Corundum","刚玉",zh-CN
+"Corvette","轻护舰",zh-CN
+"Corvus","乌黑",zh-CN
+"Couloir Shoes","幽谷鞋",zh-CN
+"Council","堂会",zh-CN
+"Council Scrip","堂会凭证",zh-CN
+"Courier","快递",zh-CN
+"Cousin Crow's Custom Craft","乌鸦表哥定制工艺",zh-CN
+"Covalex","科瓦莱什",zh-CN
+"Covalex Shipping","科瓦莱什货运",zh-CN
+"Covalex Shipping Hub Gundo","科瓦莱什货运中心 贡多",zh-CN
+"Coverall","全面覆盖",zh-CN
+"Create a better world","创造更美好的世界",zh-CN
+"Creation of Ceprozin","噻普洛嗪诞生地",zh-CN
+"creative innovation meets innovative creativity","革新创意 创造革新",zh-CN
+"Creese","马来剑",zh-CN
+"Crestfall high-tops","巅峰坠落高帮鞋",zh-CN
+"CrimeStat","犯罪等级",zh-CN
+"CrimeStat Increase","犯罪等级提升",zh-CN
+"Crimson","猩红色",zh-CN
+"Crimson Blitz","猩红闪击",zh-CN
+"Crion","克里昂",zh-CN
+"Crion Security Legion","克里昂安保军团",zh-CN
+"Crispers","脆片",zh-CN
+"Crista Tamdon","克里斯塔·坦登",zh-CN
+"CRLF DYNAPAK","疗生 医疗枪",zh-CN
+"Croshaw","克罗肖",zh-CN
+"Cross Section","横截面",zh-CN
+"Crossfield","克罗斯菲尔德",zh-CN
+"Crossfire LandCruiser","交火级陆地巡航车",zh-CN
+"Crosshair","准星报",zh-CN
+"Crowder test","拥挤者测试",zh-CN
+"Crucible","坩埚",zh-CN
+"Crude Oil","原油",zh-CN
+"Cruise Control","定速巡航",zh-CN
+"Cruiser Dog","巡航热狗",zh-CN
+"Crusader","十字军",zh-CN
+"Crusader Health Clinic","十字军健康诊所",zh-CN
+"Crusader Historical Society","十字军历史协会",zh-CN
+"Crusader Industries","十字军工业",zh-CN
+"Crusader Reservist","十字军预备役士兵",zh-CN
+"Crusader Restaurant Supply","十字军餐饮供应",zh-CN
+"Crusader Security","十字军安保",zh-CN
+"CRUZ","酷滋",zh-CN
+"Cry-Astro","寒宇",zh-CN
+"Cryo Star","冷冻之星",zh-CN
+"Cryo Star EX","冷冻之星 EX",zh-CN
+"Cryo Star SL","冷冻之星 SL",zh-CN
+"Cryo Star XL","冷冻之星 XL",zh-CN
+"CryoPod","冷冻仓",zh-CN
+"Cryptokeys","破解密钥",zh-CN
+"CS-L","CS-L",zh-CN
+"cSCU","cSCU",zh-CN
+"CTR","CTR",zh-CN
+"Cubby Blast","立方爆炸",zh-CN
+"Cubby Blast T-shirt","立方爆炸T恤",zh-CN
+"Cuesta Shoes","奎斯塔 鞋子",zh-CN
+"Cumulus","积云",zh-CN
+"CureLife","疗生公司",zh-CN
+"Custodian SMG","监管者 冲锋枪",zh-CN
+"Customs Bureau","海关局",zh-CN
+"Cutlass Black","黑弯刀",zh-CN
+"Cutlass Blue","蓝弯刀",zh-CN
+"Cutlass Red","红弯刀",zh-CN
+"Cutlass Steel","钢弯刀",zh-CN
+"Cutlass T-shirt","弯刀T恤",zh-CN
+"Cutter","小刀",zh-CN
+"Cutter Scout","小刀 侦察兵",zh-CN
+"CVSA","Cvsa Ballistic Cannon",zh-CN
+"Cyan","青色",zh-CN
+"Cyanosis","紫绀",zh-CN
+"cybernetic replacement surgeries","仿生机械义体置换手术",zh-CN
+"Cyclone","旋风",zh-CN
+"Cyclone AA","旋风 AA",zh-CN
+"Cyclone MT","旋风 MT",zh-CN
+"Cyclone RC","旋风 RC",zh-CN
+"Cyclone RN","旋风 RN",zh-CN
+"Cyclone TR","旋风 TR",zh-CN
+"Cyclops","独眼巨人",zh-CN
+"Cydnus","土蝽",zh-CN
+"Cypress","柏树",zh-CN
+"Daedalus","代达罗斯",zh-CN
+"Dafne","达夫内",zh-CN
+"Dahlia","大丽花",zh-CN
+"Daisy Wences","黛西·文斯",zh-CN
+"Dak Galbi Chicken Burrito","甜辣炒鸡卷饼",zh-CN
+"Dal “Twister” Bojang","达尔·“旋风”·博扬",zh-CN
+"Dalton Colabello","道尔顿·科拉贝洛",zh-CN
+"Damage of Property","损坏财物",zh-CN
+"Damage Reduction","伤害减免",zh-CN
+"Damage Reduction:","伤害减免：",zh-CN
+"damage type","伤害类型",zh-CN
+"Darby Keilich","达比·凯利希",zh-CN
+"Dare to Fly","一往无前",zh-CN
+"Dark Green","深绿色",zh-CN
+"Dark Grey","Rifle Green",zh-CN
+"Dark Red","暗红色",zh-CN
+"Dark Storm","暗暴",zh-CN
+"Darkside","黑暗面",zh-CN
+"Darnell Ajay","达尼尔·阿贾",zh-CN
+"Darnell Ajay Homestead","达尼尔·阿贾 定居点",zh-CN
+"Darnell ward","达尼尔·沃德",zh-CN
+"Dash Harlan","达什·哈兰",zh-CN
+"Dashiell Appraisal Services","达希尔评估服务",zh-CN
+"Datacache","数据缓存",zh-CN
+"Dauntless","无畏",zh-CN
+"Davi Ling","达维·玲",zh-CN
+"Davien","戴维恩",zh-CN
+"Davin","戴文",zh-CN
+"Davlos","戴弗洛",zh-CN
+"Davon O’Hara","达文·奥哈拉",zh-CN
+"Day of the Vara","瓦拉节",zh-CN
+"Day One","上工日",zh-CN
+"Day One: A New Dawn for Aremis Post","《第一天：阿雷米斯前哨站的新黎明》",zh-CN
+"Daybreak","破晓",zh-CN
+"Daymar","戴玛尔",zh-CN
+"Daymar in Bloom","花开戴玛尔",zh-CN
+"Daymar's Run","戴玛尔峡谷",zh-CN
+"Dayton Farro","代顿·法罗",zh-CN
+"De Biasio","德·比亚西奥",zh-CN
+"De Leon","德莱昂",zh-CN
+"Deacon Messer II","迪肯·梅塞尔/梅塞尔二世",zh-CN
+"Deacon Tobin","迪肯·托宾",zh-CN
+"Dead Saints","死亡圣徒",zh-CN
+"Deadeye","亡者之眼",zh-CN
+"Deadfall","致命陷阱",zh-CN
+"Deadrig Shotgun","死钻霰弹枪",zh-CN
+"Deakins Research Outpost","迪金斯科研前哨站",zh-CN
+"Dean Kellar","迪恩·凯拉",zh-CN
+"Death's Head","死亡头骨",zh-CN
+"DeathGrrrr","死亡咆哮",zh-CN
+"Debnam","迪博南",zh-CN
+"Decari","德卡利菌",zh-CN
+"Decari Pod","德卡利孢囊",zh-CN
+"Deck the Hull","盛装打扮",zh-CN
+"DeconPen","辐康笔",zh-CN
+"Decoy","诱饵弹",zh-CN
+"Deep-Space","深空",zh-CN
+"Defender","防卫者",zh-CN
+"Defenders of the Free","自由卫士",zh-CN
+"Defense","防御",zh-CN
+"Defense Committee","防务委员会",zh-CN
+"Defiance","蔑视",zh-CN
+"Defiant","挑战",zh-CN
+"Degnous Root","德古尼斯藻根",zh-CN
+"Dehydrating","口渴",zh-CN
+"Delamar","德拉玛",zh-CN
+"Delinquent Restitution","拖欠赔款",zh-CN
+"Delivery Digest","物流摘要",zh-CN
+"Dellin","德林",zh-CN
+"Delphi","【待定】Delphi / 德尔斐",zh-CN
+"Delta (1x Reflex)","德尔塔 (1倍反射)",zh-CN
+"Deltamax","德尔塔Max",zh-CN
+"Demeco","德美科",zh-CN
+"Demeco Energy Lmg","德美科 能量轻机枪",zh-CN
+"Demexatrine","地美沙群",zh-CN
+"Demon Fang Combat Knife","恶魔利齿 战术匕首",zh-CN
+"Denim Manufacturing Company","牛仔布制造公司",zh-CN
+"Dennis Gethart","丹尼斯·格哈特",zh-CN
+"Denver Samuels","丹佛·萨缪尔斯",zh-CN
+"Deo","迪欧",zh-CN
+"Deo Shirt","迪欧 衬衫",zh-CN
+"Department of Transportation and Navigation","运输与交通部",zh-CN
+"Deputy Assistant Director","助理副局长",zh-CN
+"Derelict Outpost","废弃前哨站",zh-CN
+"Derion","德隆",zh-CN
+"Desert","沙漠迷彩",zh-CN
+"Desert Digital","沙漠迷彩",zh-CN
+"Desert Planet","沙漠行星",zh-CN
+"Desert Shadow","沙漠之影",zh-CN
+"Destiny","命运",zh-CN
+"Destruction of Property","毁坏财物",zh-CN
+"Destruction of Vehicle","毁坏载具",zh-CN
+"detatium fruit","毒陀果",zh-CN
+"detatrine","得他啶",zh-CN
+"DetoxPen","解毒笔",zh-CN
+"Devastator","破坏者",zh-CN
+"Devastator Energy Shotgun","破坏者 能量霰弹枪",zh-CN
+"DevCo Group","发展合作集团",zh-CN
+"Devereaux","德维尔科斯",zh-CN
+"Devin ""Scorch"" Marcus","德温·“ 斯考奇”·马库",zh-CN
+"Devlin Scrap & Salvage","德夫林废品回收站",zh-CN
+"Devoue","奉献",zh-CN
+"Diamond","钻石",zh-CN
+"Diamond Laminate","钻石层压板",zh-CN
+"different is good","与众不同 卓荦不凡",zh-CN
+"Diligence","勤奋",zh-CN
+"Diluthermex","稀热树脂",zh-CN
+"Dina Deloit","迪娜·德洛特",zh-CN
+"Dina Rhogen","迪纳·欧金",zh-CN
+"Dino Benson","迪诺·本森",zh-CN
+"Dinyx Solventation","德尼克斯熔解法",zh-CN
+"Director","局长",zh-CN
+"Discovered","探索频道",zh-CN
+"Dispatcher","调度员",zh-CN
+"Dispatches from the Dark","暗影急件",zh-CN
+"Distilled Spirits","蒸馏酒精",zh-CN
+"Distortion","畸变",zh-CN
+"distribution center","配送中心",zh-CN
+"divestment","转让",zh-CN
+"DMC","丹宁牛仔",zh-CN
+"dogwood","梾木",zh-CN
+"Dolivine","暗橄榄石",zh-CN
+"Dominator","统治者",zh-CN
+"Dominic Martino","多米尼克·马蒂诺",zh-CN
+"Donnell Flanagan","唐纳尔·佛拉纳根",zh-CN
+"Donny","唐尼",zh-CN
+"DoNoNo","多诺诺",zh-CN
+"Doomsday","末日护甲",zh-CN
+"Dopple","多普勒",zh-CN
+"Double Dog","双管热狗",zh-CN
+"Dovo","都沃",zh-CN
+"DR-XJ1","DR Model-XJ1",zh-CN
+"DR-XJ2","DR Model-XJ2",zh-CN
+"DR-XJ3","DR Model-XJ3",zh-CN
+"Dr. Colby","科尔比医生",zh-CN
+"Dr. Pontrous","蓬图尔斯博士",zh-CN
+"Dracaena Pura","洁净龙血树",zh-CN
+"Dracaena Pura","洁净龙血树",zh-CN
+"Draco","天龙座",zh-CN
+"Dragon Stellar Transit Company","龙之星运输公司",zh-CN
+"Dragonfly","蜻蜓",zh-CN
+"Dragonfly Star Kitten","蜻蜓 星空猫",zh-CN
+"Dragonfly Yellowjacket","蜻蜓 黄胡蜂",zh-CN
+"Drake Cutter Rambler","德雷克 小刀 漫步者",zh-CN
+"Drake Interplanetary","德雷克行星际",zh-CN
+"Drake Interplanetary Defencecon","德雷克行星际防务展",zh-CN
+"Drassik","德拉西克",zh-CN
+"Draug","德劳格",zh-CN
+"Dream Wishes","梦愿",zh-CN
+"Drema Injector","美梦 注射器",zh-CN
+"Dress shoe","礼服鞋",zh-CN
+"Drift","漂泊",zh-CN
+"Drifter","漂流者",zh-CN
+"Driller","毒钻",zh-CN
+"Drivetrain","传动系统",zh-CN
+"Drizzle","""细雨""",zh-CN
+"Drop Kings","落王者",zh-CN
+"DS-12 Force Propulsion Grenade","DS-12 重力手榴弹",zh-CN
+"Duck Sword","小鸭刀",zh-CN
+"Dudley & Daughters","达德利父女空间站",zh-CN
+"Dumper's Depot","倾卸者仓库",zh-CN
+"Dumper's Depot T-shirt","倾卸者仓库 T恤",zh-CN
+"Dunder Shipping Logistics","冬德尔航运物流",zh-CN
+"Dunlow Derby","【暂定】顿洛德比",zh-CN
+"Dunlow Ridge","顿洛山脉",zh-CN
+"Dunlow Ridge Aid Shelter","顿洛山脉援助避难所",zh-CN
+"Dupree","杜普里",zh-CN
+"Durabull","杜拉博",zh-CN
+"DuraJet","杜拉汞",zh-CN
+"Durango","杜兰戈",zh-CN
+"DuraWork","笃工",zh-CN
+"Durus","杜鲁斯",zh-CN
+"Dust","尘埃",zh-CN
+"Dust Devil","尘魔",zh-CN
+"Dusters","嗜尘者",zh-CN
+"DustUp","扬尘",zh-CN
+"Dwarf Planet","矮行星",zh-CN
+"DX20","DX20",zh-CN
+"Dymantium","代曼合金",zh-CN
+"DynaFlex","高韧材料",zh-CN
+"Dynaflux","动力流",zh-CN
+"Dynamic Zoom (rel.)","动态缩放",zh-CN
+"E'tam","艾坦药草",zh-CN
+"Eager Flats","埃格平原",zh-CN
+"Eager Flats Aid Shelter","埃格平原援助避难所",zh-CN
+"Earl Chisum","厄尔·奇桑姆",zh-CN
+"Ebony","乌黑色",zh-CN
+"Echo","回声",zh-CN
+"Echo Eleven","回音十一号",zh-CN
+"Eckhart Security","埃克哈特安保",zh-CN
+"Eclipse","日蚀",zh-CN
+"Eclipse Mutual","日食保险",zh-CN
+"Eclipse T-shirt","日蚀T恤",zh-CN
+"Eco Flow","生态流",zh-CN
+"Ectio","埃克提",zh-CN
+"Ed Biollo","埃德·比奥罗",zh-CN
+"Eda","伊达",zh-CN
+"Eddie Parr","艾迪·帕尔",zh-CN
+"Edgerider sneakers","边缘骑士运动鞋",zh-CN
+"Edgewear","耐磨工装裤",zh-CN
+"EDL automated vehicle services","EDL 自动化载具服务系统",zh-CN
+"Edo Inc.","埃度公司",zh-CN
+"Edward Kesamyn","爱德华·凯萨明",zh-CN
+"Eealus","埃厄罗斯",zh-CN
+"Effective Range","有效射程",zh-CN
+"EHS","帝国健康服务",zh-CN
+"Ejection Rejection","拒绝弹射",zh-CN
+"El Filipiak","埃尔·菲利皮亚克",zh-CN
+"El Tieno","艾尔·蒂埃诺",zh-CN
+"El'sin","艾尔'欣",zh-CN
+"Elaine Ward","伊莱恩·沃德",zh-CN
+"Electric Blue","钢青 （纯色蓝）",zh-CN
+"Electromagnetic","电磁波",zh-CN
+"Electron","电子",zh-CN
+"Electrostarolysis","电解化晶提纯法",zh-CN
+"Electrostatic Ion technology","静电离子技术",zh-CN
+"Elespo","俄列斯泼",zh-CN
+"Elira Awards","艾薇拉奖",zh-CN
+"Elite Operative","精英特派人员",zh-CN
+"Ella Tieno","艾拉·蒂埃诺",zh-CN
+"Ellis","埃利斯",zh-CN
+"Ellroy Cass","埃尔罗伊·卡斯",zh-CN
+"Ellroy's","埃尔罗伊咖啡店",zh-CN
+"Elsen","埃尔森",zh-CN
+"Elsewhere","别处",zh-CN
+"Elysian Bloom","极乐花",zh-CN
+"Elysium","极乐",zh-CN
+"Ember","灰烬",zh-CN
+"Ember Storm","余烬风暴",zh-CN
+"Emergency Beacons","应急信标",zh-CN
+"Emergency Shelter","紧急避难所",zh-CN
+"Emilion","伊米里安",zh-CN
+"Emily Minot","艾米丽·米诺特",zh-CN
+"Emily Walzer","艾米丽·瓦泽",zh-CN
+"emission cloud","放射云",zh-CN
+"Emod","伊莫德",zh-CN
+"EMP Warefare","EMP战斗机",zh-CN
+"Emperor Bloom","帝王花",zh-CN
+"Emperor Blossom","帝王花",zh-CN
+"Empire Health Services","帝国健康服务",zh-CN
+"Empire Health Services Medstation","帝国健康服务医疗站",zh-CN
+"Empire Report","帝国实报",zh-CN
+"Empire Today","帝国今日",zh-CN
+"Empire Wildlife Federation","帝国野生动物协会",zh-CN
+"Empire's Overlooked","帝国的疏忽",zh-CN
+"Empyrean Park","至高庭园",zh-CN
+"Endeavor","奋进",zh-CN
+"Endeavor Biodome Pod","奋进 生态舱",zh-CN
+"Endeavor Fuel Pod","奋进 燃料舱",zh-CN
+"Endeavor General Research Pod","奋进 通用科研舱",zh-CN
+"Endeavor Landing Bay","奋进 停泊舱",zh-CN
+"Endeavor Service Equipment and Crew Pod","奋进 服务设备及人员舱",zh-CN
+"Endeavor Supercollider Pod","奋进 超级对撞机舱",zh-CN
+"Endgame","终局空间站",zh-CN
+"Endless Odyssey Station","无尽漫游站",zh-CN
+"Endo","内冷",zh-CN
+"Endurance","耐力",zh-CN
+"Energizing","充沛精力",zh-CN
+"Engineering","工程模式",zh-CN
+"Engler","恩格勒",zh-CN
+"Engler Observation Station","英格尔观察站",zh-CN
+"Ensign","少尉",zh-CN
+"Enter Atmosphere","突入大气",zh-CN
+"Entry descent & landing assist","进入、下降和着陆辅助系统",zh-CN
+"Envy","恋慕",zh-CN
+"Eos","黎明女神",zh-CN
+"EP-5 EMP Grenade","EM-5 EMP 手榴弹",zh-CN
+"EQ athletic pants","EQ 运动裤系列",zh-CN
+"Equinox","昼夜",zh-CN
+"Erebos","黑暗之神",zh-CN
+"Ergo","厄戈",zh-CN
+"Eria Quint","埃里亚·坤特",zh-CN
+"Eriesium","铍",zh-CN
+"Erin Toi","艾琳·托伊",zh-CN
+"Erma Triolo","艾尔玛·特奥罗",zh-CN
+"Erma Triolo Birthplace","艾尔玛·特奥罗的出生地",zh-CN
+"Ermer Family Farms Chibanzoo Ice Cream","埃尔默农庄千叶祖果冰淇淋",zh-CN
+"Ermer Family Farms Chocolate Ice Cream","埃尔默农庄巧克力冰淇淋",zh-CN
+"Ermer Family Farms Chocolate Milk","埃尔默农庄巧克力牛奶",zh-CN
+"Ermer Family Farms Coffee Ice Cream","埃尔默农庄咖啡冰淇淋",zh-CN
+"Ermer Family Farms Fat Free Ice Cream","埃尔默农庄无脂冰淇淋",zh-CN
+"Ermer Family Farms Lunes Ice Cream","埃尔默农庄月果冰淇淋",zh-CN
+"Es Naturelle original","天才-原味",zh-CN
+"Escalate","增幅",zh-CN
+"Escalated Fines","增额罚款",zh-CN
+"Escaped from Custody","逃离监禁",zh-CN
+"Escar Limited","埃斯卡有限公司",zh-CN
+"Esen Landari","埃森·兰达里",zh-CN
+"Esperia","埃斯佩里亚",zh-CN
+"Esquire","老爷鸡尾酒",zh-CN
+"essosouli","公会长",zh-CN
+"Esteril","无菌",zh-CN
+"Esther Hurston","艾希尔·赫斯顿",zh-CN
+"Ethan Halton","伊桑·哈尔顿",zh-CN
+"Euterpe","欧忒耳佩",zh-CN
+"Evading Arrest","逃脱逮捕",zh-CN
+"Evalight","伊娃之光",zh-CN
+"Evaporating Planet","蒸发行星",zh-CN
+"Evening Onyx","黑夜玛瑙",zh-CN
+"Evergreen","万年青",zh-CN
+"Everline Structures Incorporated","永线建筑公司",zh-CN
+"Everus Harbor","埃弗勒斯空间站",zh-CN
+"EVSD","EVSD Distortion Cannon",zh-CN
+"Exalt","擢升",zh-CN
+"Excelsior","精进",zh-CN
+"Exec","执行版",zh-CN
+"Executive","行政版",zh-CN
+"Executor","执行者",zh-CN
+"Exfiltrate","伊德里斯默认跳跃模块",zh-CN
+"Exodus","启程",zh-CN
+"Exogen","外生",zh-CN
+"Exotherm","热释",zh-CN
+"Expanse","无垠",zh-CN
+"Expedition","远征",zh-CN
+"Exploration","探索",zh-CN
+"Exploration Suit","探索服",zh-CN
+"Exploratory Services","勘探服务",zh-CN
+"Explorer","探索",zh-CN
+"Extent of Influence","管辖范围",zh-CN
+"Extreme-Risk Targets","极度危险目标",zh-CN
+"Eyaja","庆典",zh-CN
+"EZ Hab","EZ 胶囊公寓",zh-CN
+"Ezekiel Chikamoto","以西结·近本",zh-CN
+"F&V Blend Smoothie","果蔬冰沙",zh-CN
+"F55 Ballistic Lmg","F55 实弹轻机枪",zh-CN
+"F7A Hornet","F7A 大黄蜂",zh-CN
+"F7C Hornet","F7C 大黄蜂",zh-CN
+"F7C Hornet Wildfire","F7C 大黄蜂 野火",zh-CN
+"F7C-M Hornet Heartseeker","F7C-M 大黄蜂 寻心者",zh-CN
+"F7C-M Super Hornet","F7C-M 超级大黄蜂",zh-CN
+"F7C-R Hornet Tracker","F7C-R 大黄蜂 追踪者",zh-CN
+"F7C-R TRACKER","F7C-R 大黄蜂 追踪者",zh-CN
+"F7C-S GHOST","F7C-S 大黄蜂 幽灵",zh-CN
+"F7C-S Hornet Ghost","F7C-S 大黄蜂 幽灵",zh-CN
+"F8A Lightning","F8A 闪电",zh-CN
+"F8C Lightning","F8C 闪电",zh-CN
+"F8C Lightning Executive Edition","F8C 闪电 行政版",zh-CN
+"Fabian","法比安",zh-CN
+"Faction","宗派",zh-CN
+"Failure to Comply","拒绝协助执法",zh-CN
+"Faint Glen","黯淡幽谷站",zh-CN
+"Fair Chance Act","《公平机会法案》",zh-CN
+"Fairo","法伊罗",zh-CN
+"Faithful Dream Station","坚贞梦想站",zh-CN
+"Fakih Borisov","法基赫·鲍里索夫",zh-CN
+"Falco","法尔科",zh-CN
+"Falston Jumpsuit","弗斯顿 连体服",zh-CN
+"Falston Jumpsuit Shubin","弗斯顿 连体服 舒宾版",zh-CN
+"Far From Home","家远路迢",zh-CN
+"Farnes Media Partners","法恩斯媒体合作伙伴",zh-CN
+"Farook“stoneface”Norris","石面”法罗克·诺里斯",zh-CN
+"FarSight","远景",zh-CN
+"Faster Than Light Courier","超光速快递",zh-CN
+"Fatiguing","疲劳",zh-CN
+"Favor","人情",zh-CN
+"Fawley's Journey","弗利之旅",zh-CN
+"Fay Womak","菲·沃马克",zh-CN
+"FBL-8a","FBL-8a",zh-CN
+"FBL-8u Undersuit","FBL-8u 基底服",zh-CN
+"Felony","重罪",zh-CN
+"Feroh","菲洛",zh-CN
+"Ferron","费隆",zh-CN
+"Feynmaline","熵瞬晶",zh-CN
+"Fhaal Fire Kacho","法尔之火卡乔面",zh-CN
+"Fidele","忠信",zh-CN
+"Field Recon Suit","荒野侦查服",zh-CN
+"FieldLite","精简领域",zh-CN
+"Fierell Cascade","菲耶尔级联",zh-CN
+"Fighter","战斗",zh-CN
+"Fine","罚款",zh-CN
+"Finish Line","终点线",zh-CN
+"Finley","芬莉",zh-CN
+"Finley the Stormwal","风暴鲸芬莉",zh-CN
+"Fiore","菲奥蕾",zh-CN
+"Fiore's","菲奥蕾斯",zh-CN
+"fire rat","焰鼠教",zh-CN
+"Firebird","火鸟",zh-CN
+"Firebreak","火障",zh-CN
+"Firebrick","火砖色",zh-CN
+"Firestorm Energy Weapon","火雨能量武器",zh-CN
+"Firestorm Kinetics","火焰风暴动力学",zh-CN
+"FirmWear","坚稳着装",zh-CN
+"FirmWear SoundGuard","坚稳着装-音卫",zh-CN
+"First Contact Day","初次接触日",zh-CN
+"First Responder Trainee","见习快速响应者",zh-CN
+"First Response","第一响应",zh-CN
+"Fish Ringers","鱼柳餐馆",zh-CN
+"Fissure","裂缝",zh-CN
+"Fixed Mav Thruster","联合式机动推进器",zh-CN
+"Fizzz Cola","飞滋可乐",zh-CN
+"Fizzz diet cola","飞滋可乐-健怡",zh-CN
+"Fizzz Muscat","飞滋可乐-麝香葡萄味",zh-CN
+"Fizzz Peach","飞滋可乐-桃子味",zh-CN
+"Fizzz Soursop","飞滋可乐-番荔枝味",zh-CN
+"Fizzz Triple Berry","飞滋可乐-三重果味",zh-CN
+"FL-11","FL-11",zh-CN
+"FL-22","FL-22",zh-CN
+"FL-33","FL-33",zh-CN
+"Flame","炽焰",zh-CN
+"Flanagan's Pass","弗拉纳根隘口",zh-CN
+"Flanagan's Ravine Aid Shelter","弗拉纳根峪援助避难所",zh-CN
+"Flare","红外诱饵干扰弹",zh-CN
+"Flareweed","火炬草",zh-CN
+"Flash","闪电",zh-CN
+"Flash Freeze","急冻",zh-CN
+"Flashfire livery","闪火涂装",zh-CN
+"Flashfire Systems","闪火系统公司",zh-CN
+"Flashlight","战术手电",zh-CN
+"Flashtrack X","闪径 X",zh-CN
+"Flatcat Fail","扁平猫的失败",zh-CN
+"flex Thruster","旋转式推进器",zh-CN
+"Flex2 Fitness","Flex2 健身中心",zh-CN
+"Flight (Roll)","飞行 (滚转)",zh-CN
+"Flight Aim","飞行瞄准",zh-CN
+"Flight Blade","飞行刀片",zh-CN
+"Flight Mode Select Radial Menu","飞行模式环形选择菜单",zh-CN
+"Flight Movement","飞行移动",zh-CN
+"Flight Strafe","飞行平移",zh-CN
+"Flight Strafe Backward","飞行向后平移",zh-CN
+"Flight Throttle","飞行节流阀",zh-CN
+"Flight Throttle Up / Down (Rel.)","飞行节流阀 补/收",zh-CN
+"Flight-of-Fancy","幻梦花",zh-CN
+"Flightsuit","飞行服",zh-CN
+"Flint","燧石",zh-CN
+"Flood","溢流",zh-CN
+"Flood Energy","潮涌能量",zh-CN
+"Flow Modifier","流速调节",zh-CN
+"Fluorine","氟",zh-CN
+"Flynn ""Dusty"" Mathis","弗林·“扬尘""·马西斯",zh-CN
+"FocalWave","焦点波",zh-CN
+"Food","食物",zh-CN
+"food and beverage manufactuer","饮食生产商",zh-CN
+"fool's run","愚者赛道",zh-CN
+"Fora","芙拉",zh-CN
+"Forcewall","防御之墙",zh-CN
+"Forest","森绿色",zh-CN
+"Forgiveness","宽恕",zh-CN
+"Fortified Armor","坚甲",zh-CN
+"Fortifier","筑城",zh-CN
+"Fortifier Neoni Mod/Modification","尼奥尼防御工事模组/修改",zh-CN
+"Fortitude","刚毅",zh-CN
+"Fortress Palm","堡垒棕榈",zh-CN
+"Fortuna","福尔图娜",zh-CN
+"Fortune","财运",zh-CN
+"Fotia","福蒂雅",zh-CN
+"Fotia Scrub","炽焰灌木",zh-CN
+"Foundation Black","基础裤 黑色",zh-CN
+"Foundation Desert","基础裤 土黄色",zh-CN
+"Foundation Fest","奠基节",zh-CN
+"Foundation Festival","奠基节",zh-CN
+"Foundation Festival Beanie","奠基节 毛线帽",zh-CN
+"Foundation Festival Hat","奠基节 帽子",zh-CN
+"Foundation Grey","基础裤 灰白色",zh-CN
+"Foundation Khaki","基础裤 卡其色",zh-CN
+"Foundation Olive","基础裤 橄榄绿色",zh-CN
+"Foundation Undersuit","基础 基底服",zh-CN
+"Foundry's Fire","铸造之炎",zh-CN
+"FoveaInc","窝地矿业",zh-CN
+"Foxfire","狐火",zh-CN
+"Foxwell Enforcement","福克斯韦尔安保",zh-CN
+"FPS Movement","第一人称移动",zh-CN
+"FPS Movement (Forward/Backward/Left/Right)","第一人称移动（前/后/左/右）",zh-CN
+"Fr-66","Fr-66",zh-CN
+"Fr-76","Fr-76",zh-CN
+"Fr-86","Fr-86",zh-CN
+"Fractus","碎云",zh-CN
+"Francine Konello","弗兰辛·科内罗",zh-CN
+"Francine Udell","弗朗辛·乌德尔",zh-CN
+"Francis the Stormwal","风暴鲸弗朗西斯",zh-CN
+"Franz pants","弗兰茨 长裤",zh-CN
+"Free Look Mode","自由视角模式",zh-CN
+"Freelancer","自由枪骑兵",zh-CN
+"Freelancer DUR","自由枪骑兵 DUR",zh-CN
+"Freelancer MAX","自由枪骑兵 MAX",zh-CN
+"Freelancer MIS","自由枪骑兵 MIS",zh-CN
+"Freeman Act","自由民法案",zh-CN
+"Freeze","""冻滞""",zh-CN
+"Freight Elevator","货运电梯",zh-CN
+"Fresh eyes bring fresh innovation","新眼光带来新创新",zh-CN
+"Fresh Food","新鲜食品",zh-CN
+"Fresh Garden Smoothie","清新花园冰沙",zh-CN
+"Fresnel","菲涅耳",zh-CN
+"Freund Family Fuel","弗洛恩德家族燃料公司",zh-CN
+"Fridan","弗里达",zh-CN
+"Frigate","护卫舰",zh-CN
+"Friskers Semiconductor Inc.","检索器半导体有限公司",zh-CN
+"From:","发件人：",zh-CN
+"Frontier 05 Classic","弗龙捷 05 经典款",zh-CN
+"Frontier 05 Harvest","弗龙捷 05 橄黄色",zh-CN
+"Frontier 05 Noble","弗龙捷 05 贵族蓝色",zh-CN
+"Frontier 05 Spring","弗龙捷 05 春绿色",zh-CN
+"Frontier 05 Winter","弗龙捷 05 白色",zh-CN
+"Frontier Fighters","边境战士",zh-CN
+"Frontline","前线",zh-CN
+"Frost Bite","冻伤",zh-CN
+"Frost Burn","霜蚀",zh-CN
+"Frost Line","霜冻线",zh-CN
+"Frost Star","寒霜之星",zh-CN
+"Frost Star EX","寒霜之星 EX",zh-CN
+"Frost Star SL","寒霜之星 SL",zh-CN
+"Frost Star XL","寒霜之星 XL",zh-CN
+"Frostbite","冻霜/寒霜镇",zh-CN
+"Frostbite Camo","霜冻迷彩",zh-CN
+"FS-9 Ballistic LMG","FS-9 实弹轻机枪",zh-CN
+"FS-9H Ballistic HMG","FS-9H 实弹重机枪",zh-CN
+"FSK-8 Combat Knife","FSK-8 战术匕首",zh-CN
+"FTL Courier","超光速快递",zh-CN
+"FTL Courier Service","超光速快递服务",zh-CN
+"Fuego","弗果",zh-CN
+"fuel intake","燃料摄入口",zh-CN
+"fuel nozzle","燃料喷嘴",zh-CN
+"Fuel Pod","燃料舱",zh-CN
+"Fuel Pump","燃料泵服务",zh-CN
+"Fugitive Recovery Certification","抓捕逃犯执照",zh-CN
+"Fujin City","风神市",zh-CN
+"Fulgur","灿烂",zh-CN
+"Full Frost","冻结",zh-CN
+"Fullback","后卫",zh-CN
+"Fullblock","完全格挡",zh-CN
+"Fullforce","全力",zh-CN
+"Fullforce Pro","全力 专业",zh-CN
+"FullStop","完全停滞",zh-CN
+"Fury","狂怒",zh-CN
+"fusion engine","核融合引擎",zh-CN
+"G-Force Tolerance:","G力耐受：",zh-CN
+"G-Loc Bar","G-Loc 酒吧",zh-CN
+"G-Loc T-shirt","G-Loc T恤",zh-CN
+"G12","G12",zh-CN
+"G12a","G12a",zh-CN
+"G12r","G12r",zh-CN
+"Gadget","器具",zh-CN
+"Gaia","盖亚",zh-CN
+"Gaia Planet Services","盖亚行星服务",zh-CN
+"Gainey","盖尼",zh-CN
+"Gainsboro","淡灰色",zh-CN
+"Galactapedia","银河百科",zh-CN
+"Galactic Guide","寰宇指南",zh-CN
+"Galaxy","银河",zh-CN
+"Gale","狂风",zh-CN
+"Galen Surgical Scrub Pants","盖伦 手术服 裤子",zh-CN
+"Galen Surgical Scrub Top","盖伦 手术服 上衣",zh-CN
+"Galen Walsh","伽林·沃尔什",zh-CN
+"Galinstan","液态合金",zh-CN
+"Gallant","加伦特",zh-CN
+"Gallant Energy Rifle","加伦特 能量步枪",zh-CN
+"Gallenson Tactical Systems","加仑森战术系统",zh-CN
+"Gallete Family Farms","加莱特家庭种植站",zh-CN
+"Gallina Leigh Dougan","加利纳·莉·杜根",zh-CN
+"Gallivan Publishing","加利文出版社",zh-CN
+"Galor Messer","加勒·梅塞尔",zh-CN
+"Gamma (1x Holographic)","伽马 (1 倍全息)",zh-CN
+"Gamma Duo (2x Holographic)","伽马 Duo (2 倍全息)",zh-CN
+"Gamma Plus (3x Holographic)","伽马 Plus (3 倍全息)",zh-CN
+"GammaMax","伽马Max",zh-CN
+"Gang Tour","狂徒之旅",zh-CN
+"Garcia's Greens","加西亚蔬果",zh-CN
+"Garet Coliga","加雷特·科利加",zh-CN
+"Gargant","巨灵",zh-CN
+"Garrity Defense","加里蒂防具",zh-CN
+"Garron","盖隆",zh-CN
+"Gary Copley","加里·科普利",zh-CN
+"Gas","气体",zh-CN
+"gas cloud","气云",zh-CN
+"Gas Dwarf","低质量气态行星",zh-CN
+"Gas Giant","气态巨行星",zh-CN
+"gas pocket","气团",zh-CN
+"Gaskin Process","加斯金提纯法",zh-CN
+"Gaslight","煤气灯空间站",zh-CN
+"Gasping Weevil","窒息象鼻虫",zh-CN
+"Gasping Weevil Eggs","窒息象鼻虫卵",zh-CN
+"Gatac","盖塔克",zh-CN
+"Gatac Manufacture","盖塔克制造",zh-CN
+"Gateway","星门",zh-CN
+"Gatling","加特林",zh-CN
+"gauge","号",zh-CN
+"Gauntlet","金属护手",zh-CN
+"Gavin E. Hurston","加文·E·赫斯顿",zh-CN
+"Gavin Snarm","加文·斯纳姆",zh-CN
+"GCD-Army","GCD-陆军",zh-CN
+"Geddon","格登",zh-CN
+"Geist","幽影",zh-CN
+"Gelid","若冰",zh-CN
+"Gemini","双子座",zh-CN
+"Gems emerald","祖母绿",zh-CN
+"Gen","宗星",zh-CN
+"Gen Liberty Ale (Bottle)","利伯蒂啤酒-宗星（瓶装）",zh-CN
+"Gen12","Gen12",zh-CN
+"Genady Kuzo","詹尼迪·库佐",zh-CN
+"General","上将",zh-CN
+"General Dogsbody","苦役号",zh-CN
+"Generalist","多用途",zh-CN
+"Genesis","创世纪/基尼西斯",zh-CN
+"Genesis Starliner","创世纪 星际客机",zh-CN
+"Genesis Terraforming","创世纪地球化改造公司",zh-CN
+"Genevieve Miko","吉纳维芙·米科",zh-CN
+"Genly Engineering Solutions","温柔工程方案",zh-CN
+"Genly Maupin","让利·莫平",zh-CN
+"Genoa","热那亚",zh-CN
+"GEO","GEO",zh-CN
+"Geoffrey","杰弗里",zh-CN
+"Get Up Coffee (Black)","起床咖啡（黑咖啡）",zh-CN
+"Get Up Coffee (Cinnamon)","起床咖啡（肉桂咖啡）",zh-CN
+"Get Up Coffee (Decaf)","起床咖啡（脱因咖啡）",zh-CN
+"Get Up Coffee (Milk)","起床咖啡（牛奶咖啡）",zh-CN
+"Get Up Coffee (Mocha)","起床咖啡（摩卡咖啡）",zh-CN
+"Ghost","幽灵迷彩",zh-CN
+"Ghost Hollow","幽灵洼地",zh-CN
+"Ghost Rocks","幽灵岩",zh-CN
+"Giants-Giant-M","红巨星",zh-CN
+"Gibbs","吉布斯",zh-CN
+"Giboshi Bane","苦痛拟宝珠",zh-CN
+"Gideon","基甸",zh-CN
+"Gilbert Malagon","吉尔伯特·马拉贡",zh-CN
+"Gilick","一路好运",zh-CN
+"Gilly's Flight School","吉利飞行学校",zh-CN
+"Gin & Tonic","金汤力鸡尾酒",zh-CN
+"Ginger Five-Spice Kacho","生姜五香卡乔面",zh-CN
+"Gino's Hot Bird","吉诺热鸟",zh-CN
+"Ginzel","金杰尔",zh-CN
+"Giotto","乔托",zh-CN
+"Giotto Crusader Edition","乔托 十字军版",zh-CN
+"Giuseppe Sadaf-Pansardi","朱塞佩·萨达夫·潘萨迪",zh-CN
+"GJ 667Cc","GJ 667Cc",zh-CN
+"Glaciem Ring","冰川环带",zh-CN
+"Glacier","冰川",zh-CN
+"Glacis","斜堤",zh-CN
+"Glacosite","冰碛棉",zh-CN
+"Gladiator","角斗士",zh-CN
+"Gladius","短剑",zh-CN
+"Gladius Pirate","短剑 海盗版",zh-CN
+"Gladius Valiant","短剑 勇士",zh-CN
+"Glaive","长刀",zh-CN
+"Glas Datapad","Glas 数据平板",zh-CN
+"GlasOS Blizzard","GlasOS 暴风雪",zh-CN
+"Gliese","葛利斯",zh-CN
+"Global Inventory","总物品库",zh-CN
+"Gloria Mesa","格洛丽亚·梅萨",zh-CN
+"Gloria Theolone","格洛丽亚·塞洛隆",zh-CN
+"Gloves","手套",zh-CN
+"Glow","光热",zh-CN
+"GM (Geodesic Marker)","测地标记",zh-CN
+"GME 240-15 Patient Slippers","GME 240-15 病号拖鞋",zh-CN
+"GME 338-10 Medical Gown","GME 338-10 医疗长袍",zh-CN
+"GNP","新范式集团",zh-CN
+"Godmother Sandwich","教母三明治",zh-CN
+"Gold","金",zh-CN
+"Gold Horizon","黄金地平线",zh-CN
+"Gold/Golden","金色",zh-CN
+"Golden Dawn","金色黎明",zh-CN
+"Golden Medmon","黄金麦德蒙果",zh-CN
+"Goldenrod","一枝黄花/秋麒麟",zh-CN
+"GoldMedmons","黄金麦德蒙果",zh-CN
+"Golem","魔像",zh-CN
+"Golem-Tek","魔像技术",zh-CN
+"Goliath","哥利亚",zh-CN
+"Good Boot","良靴",zh-CN
+"Good Gift","好礼",zh-CN
+"Good Times Temple","美好时光神庙",zh-CN
+"Goodbye Geyser","诀别间歇泉",zh-CN
+"Gordon Hogland","戈登·霍格兰",zh-CN
+"Gorgon Defender Industries","戈贡防御工业",zh-CN
+"Goss","格斯",zh-CN
+"Gotlieb Yorm","戈特利布·约姆",zh-CN
+"Governance Modernization Act","现代化治理法案",zh-CN
+"Governing Committee","管理委员会",zh-CN
+"Government Cartography Agency Medal (Pristine)","政府制图局勋章（完好）",zh-CN
+"Governor","总督",zh-CN
+"GP-33 ""MOD"" Grenade Launcher mag","GP-33 ""MOD"" 榴弹发射器弹药箱",zh-CN
+"GP-33 Grenade Launcher","GP-33 榴弹发射器",zh-CN
+"GP-88","GP-88",zh-CN
+"Grab 'N Go","外带美味",zh-CN
+"Gracia's Greens","加西亚蔬果",zh-CN
+"Grade","级别",zh-CN
+"Grammercy Food Service","格拉梅西食品服务",zh-CN
+"Grand Admiral","元帅",zh-CN
+"Grand Barter Clothing Stall","大易货服装摊",zh-CN
+"Grand Flabellum","大扇叶树",zh-CN
+"GranTec","GranTec",zh-CN
+"Grappler","格斗家",zh-CN
+"Graupel","软雹",zh-CN
+"Gravlev","重力悬浮/悬浮/反重力",zh-CN
+"Green","格林星",zh-CN
+"Green and Gold Livery","绿色和金色涂装",zh-CN
+"Green Blend Smoothie","蔬菜冰沙",zh-CN
+"Green Circle Habitation","绿环住宅",zh-CN
+"Green Circle Lobby","绿环大厅",zh-CN
+"Green Circle Habitation","绿环住宅",zh-CN
+"Green Curry Primavera","绿咖喱之春",zh-CN
+"Green Glade Station","绿色林地站",zh-CN
+"Green Imperial","格林皇家",zh-CN
+"Green Imperial Insurance","格林皇家保险中心",zh-CN
+"Green Imperial Medical","格林皇家医疗中心",zh-CN
+"Green Vitality Smoothie","绿色活力冰沙",zh-CN
+"Greenwater","格林沃特",zh-CN
+"Greg Caldwell","格雷格·考德威尔",zh-CN
+"Grenade","手榴弹",zh-CN
+"Grey","灰色",zh-CN
+"Grey's","格雷",zh-CN
+"Grey's Market","格雷黑市",zh-CN
+"Greycat","灰猫",zh-CN
+"Greycat Industrial","灰猫工业",zh-CN
+"Greycat Industries","灰猫工厂",zh-CN
+"Greycat ROC","灰猫 ROC",zh-CN
+"Greycat ROC-DS","灰猫 ROC-双人版",zh-CN
+"Grievous Bodily Harm","严重人体伤害",zh-CN
+"Grim HEX","六角湾",zh-CN
+"Grim HEX (Green Imperial Housing Exchange)","六角湾（格林皇家住宅交易所）",zh-CN
+"GRIN","灰猫",zh-CN
+"Grindstone/Grindstone Boots","碎石匠",zh-CN
+"Ground Vehicle","地面载具",zh-CN
+"Groupe Nouveau Paradigme","新范式集团",zh-CN
+"Guard","守卫",zh-CN
+"Guardian","守护者/守卫",zh-CN
+"Guardian Undersuit","守卫基底服",zh-CN
+"GuideStar","引路之星",zh-CN
+"Gunmetal","炮铜色",zh-CN
+"Gunnery Sergeant","中士",zh-CN
+"Gunship","炮艇",zh-CN
+"Gurzil","古尔兹尔",zh-CN
+"GVSR","GVSR Laser Repeater",zh-CN
+"GW-9 Diagnostics Cart","GW-9 诊断推车",zh-CN
+"Gyson","吉森",zh-CN
+"Gyson Inc.","吉森公司",zh-CN
+"Hab","居住区",zh-CN
+"Habidash","哈比达什",zh-CN
+"hadanite","哈丹水晶",zh-CN
+"Hades","哈迪斯",zh-CN
+"Hadesian","哈迪斯",zh-CN
+"Hadrian","哈德良",zh-CN
+"Hadur","哈杜尔",zh-CN
+"Halcyon","平安",zh-CN
+"Haldor Lily","赫尔多百合",zh-CN
+"Halogen","卤素",zh-CN
+"Haltur","哈尔图",zh-CN
+"Ham and Cheese Sandwich","火腿芝士三明治",zh-CN
+"Hammer Propulsion","锤头推进",zh-CN
+"Hammerfall","落锤",zh-CN
+"Hammerhead","锤头鲨",zh-CN
+"Hands","手部",zh-CN
+"Hannu","汉努",zh-CN
+"Harboring a Fugitive","包庇罪犯",zh-CN
+"Hardean","哈迪安",zh-CN
+"Hardin Tactical","哈丁战术",zh-CN
+"Hardline","强硬路线",zh-CN
+"Hardpoint Guys","硬汉",zh-CN
+"Hardy","糙汉",zh-CN
+"Harkin","哈金",zh-CN
+"Harlowe Shirt","哈洛衬衫",zh-CN
+"Haros","哈罗斯",zh-CN
+"Hartmoore Platform","哈特莫尔平台",zh-CN
+"Haruspec","明目",zh-CN
+"harvestables","可采摘物",zh-CN
+"Harvester","收割机",zh-CN
+"Hat","帽子",zh-CN
+"Hathor Group","哈索尔集团",zh-CN
+"Hato Electronics Corporation","佐藤电子公司",zh-CN
+"Haven","港湾",zh-CN
+"Hawk","猎鹰",zh-CN
+"Hawksworth's","哈克沃斯鞋业",zh-CN
+"Hawthorn","霍桑",zh-CN
+"Hazard","危险黄",zh-CN
+"Hazard Suit","危害防护服",zh-CN
+"Haze","雾气",zh-CN
+"HDMO-Calthrope (NA)","HDMO-卡尔斯罗普矿洞（已废弃）",zh-CN
+"HDMO-Dobbs (NA)","HDMO-多布斯矿洞（已废弃）",zh-CN
+"HDMS-Ackley","HDMS-阿克莱站",zh-CN
+"HDMS-Anderson","HDMS-安德森站",zh-CN
+"HDMS-Bezdek","HDMS-贝兹德克站",zh-CN
+"HDMS-Edmond","HDMS-埃德蒙德站",zh-CN
+"HDMS-Hadley","HDMS-哈德利站",zh-CN
+"HDMS-Hahn","HDMS-哈恩站",zh-CN
+"HDMS-Lathan","HDMS-莱森站",zh-CN
+"HDMS-Norgaard","HDMS-诺加德站",zh-CN
+"HDMS-Oparei","HDMS-奥派雷站",zh-CN
+"HDMS-Perlman","HDMS-佩尔曼站",zh-CN
+"HDMS-Pinewood","HDMS-派恩伍德站",zh-CN
+"HDMS-Ryder","HDMS-莱德站",zh-CN
+"HDMS-Stanhope","HDMS-斯坦霍普站",zh-CN
+"HDMS-Thedus","HDMS-赛达斯站",zh-CN
+"HDMS-Woodruff","HDMS-伍德拉夫站",zh-CN
+"HDPC-Cassillo","HDPC-卡西洛",zh-CN
+"HDPC-Degland","HDPC-德格兰",zh-CN
+"HDPC-Farnesway","HDPC-法内斯威",zh-CN
+"HDPC-Tiyago","HDPC-提亚戈",zh-CN
+"HDRSO-Bramen","HDRSO-布拉曼哨所",zh-CN
+"HDSF","赫斯顿动力仓储设施",zh-CN
+"HDSF-Adlai","HDSF-阿德莱站",zh-CN
+"HDSF-Barnabas","HDSF-巴纳巴斯站",zh-CN
+"HDSF-Breckinridge","HDSF-布雷肯里奇站",zh-CN
+"HDSF-Colfax","HDSF-科尔法克斯站",zh-CN
+"HDSF-Damaris","HDSF-达莫里斯站",zh-CN
+"HDSF-Elbridge","HDSF-埃尔布里奇站",zh-CN
+"HDSF-Hendricks","HDSF-亨得利斯克站",zh-CN
+"HDSF-Hiram","HDSF-海勒姆站",zh-CN
+"HDSF-Hobart","HDSF-霍巴特站",zh-CN
+"HDSF-Ishmael","HDSF-以赛玛利站",zh-CN
+"HDSF-Millerand","HDSF-米尔兰德站",zh-CN
+"HDSF-Rufus","HDSF-卢福斯站",zh-CN
+"HDSF-Sherman","HDSF-谢尔曼站",zh-CN
+"HDSF-Tamar","HDSF-塔玛站",zh-CN
+"HDSF-Tompkins","HDSF-汤普金斯站",zh-CN
+"HDSF-Zacharias","HDSF-撒加利亚站",zh-CN
+"Headhunter","猎头帮",zh-CN
+"headhunters","猎头帮",zh-CN
+"Headwear","头饰",zh-CN
+"Healing","治愈",zh-CN
+"health","健康值",zh-CN
+"Heart of the Woods","森林之心",zh-CN
+"HeartStone PDS","心石 小儿除颤系统",zh-CN
+"Heartthrob","心动",zh-CN
+"Heat","热量",zh-CN
+"Heat Safe","安全热控",zh-CN
+"Heat Sink","热逝之槽",zh-CN
+"Heatwave","热浪",zh-CN
+"Heavy bomber","重型轰炸",zh-CN
+"Heavy Coat","厚大衣",zh-CN
+"Hebe's Perch","恒青台",zh-CN
+"Hedeby Gunworks","赫德比枪械",zh-CN
+"HEI","水合功效指数",zh-CN
+"Helios","赫里欧斯",zh-CN
+"Helix","螺旋",zh-CN
+"Hellion","恶棍",zh-CN
+"Hello Sunshine","赞美阳光",zh-CN
+"Helmet","头盔",zh-CN
+"Hemera","白昼女神",zh-CN
+"Hemozal","血红扎",zh-CN
+"Henry Garrity","亨利·加里蒂",zh-CN
+"Hephaestanite","火神石",zh-CN
+"Herald","信使",zh-CN
+"HERCULES STARLIFTER","大力神 星际运输船",zh-CN
+"Hercules Starlifter Flight Jacket","大力神星际运输机 飞行夹克",zh-CN
+"Hermes","赫尔墨斯",zh-CN
+"Herschel Food","赫歇尔食品",zh-CN
+"Hex","六角",zh-CN
+"HexaPolyMesh Coating","六边形涂层",zh-CN
+"Hi&Tight","趁足",zh-CN
+"Hi-Vis Yellow","醒目黄",zh-CN
+"Hickes Research Outpost","希克斯研究种植站",zh-CN
+"Hidden Design","《隐藏的设计》",zh-CN
+"High Course Station","高速路线站",zh-CN
+"High-Advocate","最高督导长",zh-CN
+"High-Command","最高统帅部",zh-CN
+"High-Command Legatus Exercitus","陆军总长",zh-CN
+"High-Command Legatus Marinuum","陆战队总长",zh-CN
+"High-Command Legatus Navium","海军总长",zh-CN
+"High-Risk Targets","高风险目标",zh-CN
+"High-Secretary","最高秘书长",zh-CN
+"Highpoint Wilderness Specialists","高境荒野专家公司",zh-CN
+"Historical Truth Act","历史真相法案",zh-CN
+"HLX99 Hyperprocessors","HLX99 疯牛处理器",zh-CN
+"Hockrow Agency","霍克罗事务所",zh-CN
+"Hoffdor (Bottle)","霍夫多啤酒（瓶装）",zh-CN
+"Hofstede","霍夫斯泰德",zh-CN
+"Holdstrong","坚盾",zh-CN
+"Holiday Butcher Helmet","假日屠夫 头盔",zh-CN
+"Home","【待定】主页",zh-CN
+"Homicide","蓄意谋杀",zh-CN
+"Horde","部落",zh-CN
+"Horizon Crew","地平线组织",zh-CN
+"Horizon Helmet","地平线头盔",zh-CN
+"Hornet","大黄蜂",zh-CN
+"Horus","荷鲁斯",zh-CN
+"Hosanna","和撒那树",zh-CN
+"Hoshki Center","霍斯基中心",zh-CN
+"HoverQuad","悬浮驷",zh-CN
+"HP-284 Rocket Launcher","HP-284 火箭发射器",zh-CN
+"Hui'a Puzzle","慧亚拼图",zh-CN
+"Hull A","货轮 A",zh-CN
+"Hull B","货轮 B",zh-CN
+"Hull C","货轮 C",zh-CN
+"Hull D","货轮 D",zh-CN
+"Hull E","货轮 E",zh-CN
+"Human","人类",zh-CN
+"Human Food Bars","人类食品棒",zh-CN
+"Humboldt Mines","洪保德矿站",zh-CN
+"Huracan","乌拉坎",zh-CN
+"Hurricane","飓风",zh-CN
+"Hurston","赫斯顿",zh-CN
+"Hurston Dynamics","赫斯顿动力",zh-CN
+"Hurston Group Assurance","赫斯顿集团保险",zh-CN
+"Hurston Hotline","赫斯顿热线",zh-CN
+"Hurston Security","赫斯顿安保",zh-CN
+"Hydra Propulsion","九头蛇推进",zh-CN
+"Hydrating","补水",zh-CN
+"Hydration Efficacy Index","水合功效指数",zh-CN
+"Hydro Jet","喷射",zh-CN
+"Hydrocel","水凝",zh-CN
+"Hydrogen","氢气",zh-CN
+"Hydropulse","水冷脉冲",zh-CN
+"Hyoton","亥由通",zh-CN
+"Hyper Vanguard Force","超先锋之力",zh-CN
+"Hypergen","极生",zh-CN
+"Hyperion","亥伯隆",zh-CN
+"Hypermetabolic","加速代谢",zh-CN
+"Hypertrophic","肌力充沛",zh-CN
+"Hypometabolic","延缓代谢",zh-CN
+"IAE 2950 Hat","IAE 2950 帽子",zh-CN
+"IAE 2950 T-shirt","IAE 2950 T恤",zh-CN
+"IAE 2952 Hat","IAE 2952 帽子",zh-CN
+"IAE 2952 T-shirt","IAE 2952 T恤",zh-CN
+"Ibrahim Sphere","易卜拉欣球",zh-CN
+"Ice Box","冰块",zh-CN
+"Ice Dive","冰潜",zh-CN
+"Ice Flush","冰冲",zh-CN
+"Ice Giant","冰巨行星",zh-CN
+"Ice Planet","冰封星球",zh-CN
+"Ice Plunge","冰浴",zh-CN
+"Icebound Livery","冰封涂装",zh-CN
+"IceBreak","破冰",zh-CN
+"icePick","碎冰锥",zh-CN
+"icePick Cryptokey","碎冰锥 破解密钥",zh-CN
+"Ido","艾度",zh-CN
+"Idris","伊德里斯",zh-CN
+"Idris Air Hawks","伊德里斯空鹰队",zh-CN
+"Idris-K","伊德里斯-K",zh-CN
+"Idris-M","伊德里斯-M",zh-CN
+"Idris-P","伊德里斯-P",zh-CN
+"IFFI","敌我识别反转器",zh-CN
+"Ignacio Slade","伊格纳西奥·斯莱德",zh-CN
+"Ignis","伊格尼斯",zh-CN
+"Ignite","点火",zh-CN
+"Ilyyaana Sharrad","伊利亚娜·莎拉德",zh-CN
+"Immune Boosting","免疫增强",zh-CN
+"Immune Suppressing","免疫下降",zh-CN
+"Imperator","皇帝",zh-CN
+"Imperator Costigan on Cellin","科斯蒂根皇帝访问赛琳",zh-CN
+"Imperial","帝国版",zh-CN
+"Imperial Cartography Center","帝国制图中心",zh-CN
+"Imperial Engineering Expo","帝国工程技术展",zh-CN
+"Imperial Finances","帝国金融",zh-CN
+"Imperial General Insurance","帝国通用保险",zh-CN
+"Imperial Red","帝国红",zh-CN
+"Imperial Trio Kacho","皇家三重唱卡乔面",zh-CN
+"Imprint","印记",zh-CN
+"Impulse","脉冲",zh-CN
+"Incapacitated","丧失行动能力",zh-CN
+"Incredifun Adventures","超乐探险",zh-CN
+"Indra","因德拉",zh-CN
+"IndVest","英迪上装",zh-CN
+"Inert Materials","惰性物质",zh-CN
+"Infiltration","渗透船",zh-CN
+"Infinity Custom","无限定制",zh-CN
+"Info Runner","信息搜集",zh-CN
+"Infrared","红外线",zh-CN
+"Injury","伤势",zh-CN
+"Ink","墨水",zh-CN
+"Inmate Homicide","谋杀狱友",zh-CN
+"Inquisitor","审讯官",zh-CN
+"INS Jericho","INS 杰里科",zh-CN
+"Inspiration Business Park","灵感商业园区",zh-CN
+"Inspire","启发",zh-CN
+"Insta-Friends","“好兄弟”",zh-CN
+"Insurance Fraud","保险欺诈",zh-CN
+"Interceptor","截击",zh-CN
+"InterDimension Software","互动维度软件",zh-CN
+"Intergalactic Aerospace Expo","星际航空航天博览会",zh-CN
+"InterSec Defense Solutions","互安防务",zh-CN
+"Interspace","隙空间",zh-CN
+"Interstellar Transport Guild","星际运输公会",zh-CN
+"Intrepid","无畏",zh-CN
+"Inversion Settings","反转设置",zh-CN
+"Invert Flight Controller Vertical Axis","飞行控制器纵轴反转",zh-CN
+"Invert Flight Mouse Vertical Axis","飞行鼠控纵轴反转",zh-CN
+"Invert Pitch","俯仰反转",zh-CN
+"Invert Roll","滚转反转",zh-CN
+"Invert Yaw","偏转反转",zh-CN
+"Invictus","不败舰队周",zh-CN
+"Invictus Blue and Gold","不败蓝金",zh-CN
+"Invictus Flight Jacket","不败雄心飞行夹克",zh-CN
+"Invictus Flyby","不败舰队巡航",zh-CN
+"Invictus Launch Fleet","不败舰队",zh-CN
+"Invictus Launch Week","不败舰队启航周",zh-CN
+"IO-North","IO-北区",zh-CN
+"Iodine","碘",zh-CN
+"Iolo Industries","洛洛工业",zh-CN
+"Ionburst","离子爆裂",zh-CN
+"Ionsurge","离子奔涌",zh-CN
+"Ionsurge Pro","离子奔涌 Pro",zh-CN
+"Ionwave","离子波",zh-CN
+"Irena Adjei","伊雷娜·阿耶伊",zh-CN
+"Iron Adze","铁斧啤酒",zh-CN
+"Iron Planet","铁质行星",zh-CN
+"IronBand","钢铁地带",zh-CN
+"Ironclad","铁甲",zh-CN
+"Ironscale Livery","铁鳞涂装",zh-CN
+"Ironside","铁骑",zh-CN
+"Ironweave livery","铁织涂装",zh-CN
+"Isiah Hurston","伊赛亚·赫斯顿",zh-CN
+"Isidro ""Nighthawk"" Renard","“夜鹰”伊西德罗·雷纳德",zh-CN
+"Issigon","伊西贡",zh-CN
+"issue council","问题理事会",zh-CN
+"Ita","依塔",zh-CN
+"Item Bank","物品银行",zh-CN
+"Item Type:","物品类型：",zh-CN
+"Ivar Messer","伊瓦尔·梅塞尔",zh-CN
+"Ivers","艾弗斯",zh-CN
+"Ixonia","艾修尼亚",zh-CN
+"J-Span","J-Span",zh-CN
+"Jac Ngo","杰克·恩戈",zh-CN
+"Jackal","胡狼",zh-CN
+"Jacket","夹克",zh-CN
+"Jackson's Swap","杰克森交易站",zh-CN
+"Jaclium","杰金",zh-CN
+"Jacopo Monocle","雅各布单片眼镜",zh-CN
+"Jacopo Tophat","雅各布高帽",zh-CN
+"Jaeger","猎人",zh-CN
+"Jaghte","贾格特",zh-CN
+"Jahlium","耶金",zh-CN
+"Jahr FabriCorp","雅尔纤维公司",zh-CN
+"Jalan","贾兰星",zh-CN
+"Jameis Freund","詹姆斯·弗洛恩德",zh-CN
+"Jamel Normond","贾梅尔·诺蒙德",zh-CN
+"James Romanov","詹姆斯·罗曼诺夫",zh-CN
+"James Vandyke","詹姆斯·范戴克",zh-CN
+"Jan Dredge","简·德杰",zh-CN
+"Janalite","加纳石",zh-CN
+"Janna Malone","詹纳·马龙",zh-CN
+"Janus","雅努斯",zh-CN
+"Jata","亚塔",zh-CN
+"Javelin","标枪",zh-CN
+"Jax McCleary","贾克斯·麦克莱里",zh-CN
+"Jele City","杰勒市",zh-CN
+"Jennet","詹妮特",zh-CN
+"Jericho","杰里科",zh-CN
+"Jet","乌玉",zh-CN
+"Jieto","杰托",zh-CN
+"Jing Fermi","静·费米",zh-CN
+"joint Thruster","关节式推进器",zh-CN
+"Joker Engineering","小丑工程",zh-CN
+"Joker Enterprises","小丑企业",zh-CN
+"Joker Insta-Friends Decoy Grenade","小丑""好兄弟""雷达诱导手榴弹",zh-CN
+"Jona Trevena","约纳·特雷韦纳",zh-CN
+"Jos Nurel","乔斯·努雷尔",zh-CN
+"Journeyman Tracker License Certification","职业赏金猎人执照",zh-CN
+"Joy Ferguson","乔伊·弗格森",zh-CN
+"Joystick Sensitivity Curves","操纵杆灵敏度曲线",zh-CN
+"Jr. Logistics Coordinator","初级物流协调员",zh-CN
+"Jr. Petty Officer","下士",zh-CN
+"JS-300","JS-300",zh-CN
+"JS-400","JS-400",zh-CN
+"JS-500","JS-500",zh-CN
+"Judecca","朱迪加",zh-CN
+"Judge Stun Pistol","审判 电击手枪",zh-CN
+"Julep Ravine","朱利普峡谷",zh-CN
+"Julep Ravine Aid Shelter","朱利普峡谷援助避难所",zh-CN
+"Juliana Aston","朱莉安娜·阿斯顿",zh-CN
+"Juliet Maupin","朱莉叶·莫平",zh-CN
+"Jump drive","跳跃驱动器",zh-CN
+"jump module","跳跃模块",zh-CN
+"jump point","跳跃点",zh-CN
+"jump tunnel","跳跃通道",zh-CN
+"Jumping Limes","跳跳橙",zh-CN
+"Jumptown","跃动小镇",zh-CN
+"Junior Outsourcing Agent","初级外包代理人",zh-CN
+"Junior Security Associate","初级安保助理",zh-CN
+"Juno","朱诺级",zh-CN
+"Juno Starwerk","朱诺星际工厂",zh-CN
+"Jupiter","木星",zh-CN
+"Jurisdiction(s)","管辖/管辖区",zh-CN
+"Justine","贾斯汀",zh-CN
+"Jysho Corporation","杰颂公司",zh-CN
+"K7","K7",zh-CN
+"Kabal","卡巴尔",zh-CN
+"Kacho restaurant","卡乔面餐厅",zh-CN
+"Kai'pua","凯珀",zh-CN
+"Kaizen","改善频道",zh-CN
+"Kale Sonora","卡莱·索诺拉",zh-CN
+"Kalee Ora","卡利·奥拉",zh-CN
+"Kali Hanks","卡莉·汉克斯",zh-CN
+"Kallis","卡利斯",zh-CN
+"Kama","卡玛",zh-CN
+"Kamar","卡马尔",zh-CN
+"Kampos","坎波斯",zh-CN
+"Kanile Yuder","卡尼勒·尤德",zh-CN
+"Karna","卡纳",zh-CN
+"Karna Plasma Rifle","卡纳 电浆步枪",zh-CN
+"Karoby Energy Bar (Cranberry, Green Tea & Carob)","卡罗比能量棒（蔓越莓、绿茶&稻子豆）",zh-CN
+"Karoby Energy Bar (Tahini & Carob)","卡罗比能量棒（芝麻酱&稻子豆）",zh-CN
+"Kass Dent","卡斯·登特",zh-CN
+"Kastak Arms","卡斯塔克武器",zh-CN
+"Kaswal","卡斯瓦尔",zh-CN
+"Katla","卡特拉",zh-CN
+"Katsu Karē Kacho","卡苏克尔卡乔面",zh-CN
+"Kavir","卡维尔",zh-CN
+"Kavya Crosby","卡薇雅·克罗斯比",zh-CN
+"Kay Farrah","凯·法拉赫",zh-CN
+"Kayfa","凯法",zh-CN
+"Kazen Winnowing","卡赞风选法",zh-CN
+"KC Trending","KC 潮流",zh-CN
+"KE Group","KE 集团",zh-CN
+"Keeger Belt","基格小行星带",zh-CN
+"Keisha Saeed","凯莎·萨伊德",zh-CN
+"Kel-To ConStore","科途便利店",zh-CN
+"Kel-To Rx Clinic","科途 Rx 诊所",zh-CN
+"Keldur","克尔杜尔",zh-CN
+"Kellog","凯洛格",zh-CN
+"Kelly Caplan","凯利·卡普兰",zh-CN
+"Kelos Costigan","凯洛斯·科斯蒂根",zh-CN
+"Kelvid","开尔温",zh-CN
+"Kepler","开普勒",zh-CN
+"Kesseli","凯塞利",zh-CN
+"Kesselring Heist","凯塞利林大劫案",zh-CN
+"Ketchum","凯彻姆",zh-CN
+"Kevin Walton","凯文·沃尔顿",zh-CN
+"Keyon Tyler","基恩·泰勒",zh-CN
+"Keystone","基石",zh-CN
+"Khabari","卡巴内",zh-CN
+"Khaos","混沌女神",zh-CN
+"Khartu","卡图",zh-CN
+"Khartu-al","卡图-al",zh-CN
+"Kiami","琪亚米",zh-CN
+"Kiel","基尔",zh-CN
+"Kiel Guardians","基尔卫士队",zh-CN
+"Kilgore & Poole","基尔戈&普尔",zh-CN
+"Kilgore and Poole","克林格与波罗",zh-CN
+"Kilian","基利恩",zh-CN
+"Killshot","绝杀",zh-CN
+"kingfish","无鳔石首鱼",zh-CN
+"Kingship","王船",zh-CN
+"Kino","基诺",zh-CN
+"Kins","金斯",zh-CN
+"Kins II Civilization","金斯 II 文明",zh-CN
+"Kithara","基塔拉",zh-CN
+"Kiyomi Santos","清美·桑托斯",zh-CN
+"Kiyoshi Culver","清司·卡尔弗",zh-CN
+"Klaus & Werner","克劳斯&韦纳",zh-CN
+"KLESCHER","克莱舍尔",zh-CN
+"Klescher Rehabilitation Facilities","克莱舍尔劳教所",zh-CN
+"Klescher Rehabilitation Facility","克莱舍尔劳教所",zh-CN
+"KnightBridge Arms","骑士桥军备",zh-CN
+"Koal Pants","科尔 长裤",zh-CN
+"Koli","科里星",zh-CN
+"Konjio","昆蕉",zh-CN
+"Kopion","寇骈犬",zh-CN
+"Kosmicheskie Dvigateli Kunayeva","库纳耶夫太空引擎公司",zh-CN
+"Kosso Basin","科索盆地",zh-CN
+"Kosso Basin Aid Shelter","科索盆地援助避难所",zh-CN
+"Kotto","科托",zh-CN
+"Koya","科亚",zh-CN
+"Kr'Thak","科萨克",zh-CN
+"Kragen","克拉根",zh-CN
+"Kraken","海妖",zh-CN
+"Kraken Privateer","海妖 私掠版",zh-CN
+"Krell","克雷尔",zh-CN
+"Kristin Sobotka","克里斯汀·索博特卡",zh-CN
+"Kroneg","克罗内格",zh-CN
+"Kruger","克鲁格",zh-CN
+"Kruger Intergalactic","克鲁格星际",zh-CN
+"Kudre Ore","库德雷矿井",zh-CN
+"Kudre Ore Mine (Closed)","库德雷矿井（已关闭）",zh-CN
+"Kutty","库蒂",zh-CN
+"Kyle Fenris","凯尔·芬里斯",zh-CN
+"La'uo","拉奥",zh-CN
+"Lago","拉戈",zh-CN
+"Lagrange","拉格朗日点",zh-CN
+"Lagrangian gravity","拉格朗日重力井",zh-CN
+"Lakedra Walsh","拉克德拉 瓦尔什",zh-CN
+"Lakedra's Lap","拉克德拉赛道",zh-CN
+"Lamb Tagine Combat Ration","塔吉锅羊肉战斗口粮",zh-CN
+"Lambert","兰伯特",zh-CN
+"Lamont Undersuit","拉蒙特 基底服",zh-CN
+"Lance Corporal","准下士",zh-CN
+"Landfall","登陆",zh-CN
+"landing pad","停机坪",zh-CN
+"Landlite","轻盈大地",zh-CN
+"Laranite","砬兰石",zh-CN
+"Large artifact fragment (Damaged)","大型遗物碎片（损坏）",zh-CN
+"Large Jump Point","大型跳跃点",zh-CN
+"Lars Gonall","拉尔斯·高纳尔",zh-CN
+"Laser Instability","激光不稳定性",zh-CN
+"Laska Shoes","洛什卡 鞋子",zh-CN
+"Last Ditch","最终防线",zh-CN
+"Lastaprene","耐用橡胶",zh-CN
+"Lateral","水平",zh-CN
+"Launch Pad","发射台",zh-CN
+"Lava Planet","熔岩行星",zh-CN
+"Lavelle","拉韦尔",zh-CN
+"Lavinia Wallingford","拉维尼娅·沃林福德",zh-CN
+"Laylani Addison","莱拉尼·艾迪生",zh-CN
+"Lazarus","拉撒路",zh-CN
+"Lead Security Specialist","首席安保专家",zh-CN
+"Leading Starman","一等兵",zh-CN
+"Leah","莉娅",zh-CN
+"Leavsden Station","列维斯登站",zh-CN
+"Lee Cardenza","李·卡登扎",zh-CN
+"Legatus Exercitus","陆军总长",zh-CN
+"Legatus Marinuum","陆战队总长",zh-CN
+"Legatus Navium","海军总长",zh-CN
+"Legion","军团",zh-CN
+"Legionnaire","军团兵",zh-CN
+"Legs","腿甲",zh-CN
+"Leir","利尔",zh-CN
+"Leland Wingard","利兰·温加德",zh-CN
+"LeMarque","勒马克",zh-CN
+"Lemon Lush","柠檬露诗",zh-CN
+"Lengua Sandwich","牛舌三明治",zh-CN
+"Leo Sagara","利奥·萨加拉",zh-CN
+"Leona Zion","莉欧娜·锡安",zh-CN
+"Leonids","狮子座",zh-CN
+"Les Arlington","莱斯·阿灵顿",zh-CN
+"Lesath","蝎尾",zh-CN
+"Lev Cronenberg","列夫·柯南伯格",zh-CN
+"Levin","莱文",zh-CN
+"Levski","列夫斯基",zh-CN
+"Leyland's tortoise","利兰陆龟",zh-CN
+"Leyland’s tortoise","利兰陆龟",zh-CN
+"Lh86 Ballistic Pistol","LH86 实弹手枪",zh-CN
+"Li-Tok","利托",zh-CN
+"Liaison Officer Bautista","联络官 包蒂斯塔",zh-CN
+"Liaison Officer Gibbs","联络官 吉布斯",zh-CN
+"Liana Broussard","莉安娜·布鲁萨德",zh-CN
+"Liberator","解放者",zh-CN
+"Liberty","自由港",zh-CN
+"Libio","利比奥",zh-CN
+"Libo","利波",zh-CN
+"Lieutenant","上尉",zh-CN
+"Lieutenant Junior Grade","中尉",zh-CN
+"Life Support","维生系统",zh-CN
+"Life Support Filter","维生系统过滤器",zh-CN
+"Life, Love, Loss","生命，爱情与逝去",zh-CN
+"LifeCore","生命核心",zh-CN
+"LifeCure Medsticks","护生医疗棒",zh-CN
+"LifeGuard","护生",zh-CN
+"Light Armor","轻型护甲",zh-CN
+"LIGHT CARRIER","轻型运载舰",zh-CN
+"Light Green and Grey","浅绿色和灰色",zh-CN
+"Light Grey","浅灰",zh-CN
+"Lightblossom","光绽",zh-CN
+"Lightfire","光火",zh-CN
+"Lightning Bolt Co.","雷击公司",zh-CN
+"Lightning Power Ltd.","闪电之力有限公司",zh-CN
+"Lillo","丽络",zh-CN
+"Lily Monte Salon","莉莉蒙特沙龙",zh-CN
+"Lima Endicott","利玛·恩迪科特",zh-CN
+"Lime","石灰绿",zh-CN
+"Lindinium","林登金",zh-CN
+"Lindstrom","林斯特龙",zh-CN
+"Ling Family Hauling","玲家快递",zh-CN
+"Linton Messer","林顿·梅塞尔",zh-CN
+"Lionel Ross","莱昂纳尔·罗斯",zh-CN
+"Lionheart","狮心",zh-CN
+"Live Fire Weapons","荷枪实弹武器店",zh-CN
+"Livefire weapon","荷枪实弹武器店",zh-CN
+"Lively Pathway Station","活力小径站",zh-CN
+"Livery","涂装",zh-CN
+"Livia","利维亚",zh-CN
+"Livia Fenner","利维亚·芬纳",zh-CN
+"LMG","轻机枪",zh-CN
+"Lo","罗星",zh-CN
+"Lo Classic Kacho","洛星经典卡乔面",zh-CN
+"loading area","装卸区",zh-CN
+"Loc","疯狂",zh-CN
+"Locke","洛克星",zh-CN
+"Locked-on Lentil Burrito","锁定扁豆卷",zh-CN
+"Logan Jorrit","洛根·约里特",zh-CN
+"Long Forest Station","长林站",zh-CN
+"Long jacket","风衣",zh-CN
+"Long-range Fighter","深空战斗",zh-CN
+"Looking for Lost Treasure","寻找失落的宝藏",zh-CN
+"Lorber","洛伯",zh-CN
+"Lorenzo Momar","洛伦佐·莫马尔",zh-CN
+"Lorona","洛罗纳",zh-CN
+"Lortell Computing","罗特尔信息处理公司",zh-CN
+"Lorville","罗威尔",zh-CN
+"Lorville Blues","罗威尔蓝天",zh-CN
+"Lost and Found","失物招领处",zh-CN
+"Lost Squad","《失落中队》",zh-CN
+"Lost Wallet","钱包丢了",zh-CN
+"Lotus","莲花",zh-CN
+"Louisa","路易莎",zh-CN
+"Lover's Ledge","情人崖",zh-CN
+"Loveridge Mineral Reserve","洛维里奇矿站",zh-CN
+"Lovestruck","痴情",zh-CN
+"Low Riders","粗俗骑手",zh-CN
+"Low-Risk Targets","低风险目标",zh-CN
+"Lt. Colonel","中校",zh-CN
+"Lt. Commander","少校",zh-CN
+"Lt. Con Timway","康· 蒂姆威上尉",zh-CN
+"Lt. General","中将",zh-CN
+"Luca Brunt","卢卡·布伦特",zh-CN
+"Lucas ""Gilly"" Baramsco","卢卡斯·“吉利”·巴拉姆斯科",zh-CN
+"Lucas Baramsco","卢卡斯·巴拉姆斯科",zh-CN
+"Luck's Favor Tankard","幸运眷顾啤酒杯",zh-CN
+"Luckbringer","幸运使者",zh-CN
+"Lula's Pitambu Fruit Juice","卢拉的皮坦布果汁",zh-CN
+"Lumacore","亮度核心",zh-CN
+"Lumen","流明",zh-CN
+"Lumin V Smg","卢敏 V 冲锋枪",zh-CN
+"Luminalia","光灯节",zh-CN
+"Luminalia Gift","光灯节礼物",zh-CN
+"Luna","露娜",zh-CN
+"Lunes","月果",zh-CN
+"Lux","光明",zh-CN
+"Luxcore","照度核心",zh-CN
+"Luxury Touring","奢华旅游",zh-CN
+"Lycara","莱护材料",zh-CN
+"Lynx","猞猁/天猫座",zh-CN
+"Lynx Rover","天猫座漫游车",zh-CN
+"Lyre","里尔",zh-CN
+"Lyria","莉瑞雅",zh-CN
+"M&V","M&V 酒吧",zh-CN
+"M2 Hercules","大力神 M2",zh-CN
+"M3A","M3A Laser Autocannon",zh-CN
+"M4A","M4A Laser Autocannon",zh-CN
+"M50","M50",zh-CN
+"M5A","M5A Laser Autocannon",zh-CN
+"M6A","M6A Laser Autocannon",zh-CN
+"M7A","M7A Laser Autocannon",zh-CN
+"M8A","M8A Laser Autocannon",zh-CN
+"Ma's Ready to Eat Beef Home Stew","马氏即食炖牛肉",zh-CN
+"Ma's Ready to Eat Chicken Home Stew","马氏即食炖鸡",zh-CN
+"Ma's Ready to Eat Chicken Patty Dinner","马氏即食鸡肉馅饼",zh-CN
+"Ma's Ready to Eat Fish Home Stew","马氏即食家常炖鱼",zh-CN
+"Ma's Ready to Eat Noodle Red","马氏即食红辣面",zh-CN
+"Ma's Ready to Eat Traveler's Day Dinner","马氏即食旅行者餐",zh-CN
+"Ma's Ready to Eat Vegetable Soup","马氏即食蔬菜汤",zh-CN
+"ma'xy.un","喰兽",zh-CN
+"Mac Petrosky","麦克·佩卓斯基",zh-CN
+"MacFlex","麦克福莱克斯",zh-CN
+"MacFlex ""Rucksack"" Core","麦克福莱克斯 背包胸甲",zh-CN
+"Madge Halford","玛奇·哈福德",zh-CN
+"Madras Asada Burrito","马德拉斯烤肉卷",zh-CN
+"Maelstrom","大漩涡",zh-CN
+"Magazine Size","弹匣容量",zh-CN
+"Magda","玛格达",zh-CN
+"Magic Hour","魔力时光",zh-CN
+"Magma Jet","岩浆飞射",zh-CN
+"Magnabloom","大盛",zh-CN
+"Magnus","马格努斯",zh-CN
+"Magnus Tobin","马格努斯·托宾",zh-CN
+"Mahoney Nurse Scrub Suit","马奥尼 护士服 连身衣",zh-CN
+"Maiden Group","少女集团",zh-CN
+"Main Sequence-Dwarf-A","A 型主序星",zh-CN
+"Main Sequence-Dwarf-B","B 型主序星",zh-CN
+"Main Sequence-Dwarf-F","F 型主序星",zh-CN
+"Main Sequence-Dwarf-G","G 型主序星",zh-CN
+"Main Sequence-Dwarf-K","K 型主序星",zh-CN
+"Main Sequence-Dwarf-M","M 型主序星",zh-CN
+"Main Sequence-Dwarf-O","O 型主序星",zh-CN
+"Main Sequence-Flare-M","M 型主序耀星",zh-CN
+"Major","少校",zh-CN
+"Major General","少将",zh-CN
+"Makarel Marauders","马卡雷尔掠夺者",zh-CN
+"Makau","马告",zh-CN
+"Mako McCaffrey","马科·麦卡弗里",zh-CN
+"Mala","玛拉毒素",zh-CN
+"Maltrox Arlington","马尔特克斯·阿灵顿",zh-CN
+"Manaslu","马纳斯鲁",zh-CN
+"Mandible Helmet","大颚 头盔",zh-CN
+"Manticore","蝎狮",zh-CN
+"Mantis","螳螂",zh-CN
+"Manufacturer","制造商",zh-CN
+"Marcel Broussard","马塞尔·布鲁萨德",zh-CN
+"Marcelo Amon","马塞洛·亚蒙",zh-CN
+"Marcus Albright","马库斯·奥尔布赖特",zh-CN
+"Marcus Clenn","马库斯·克伦",zh-CN
+"Marcus Fayel","马库斯·法耶尔",zh-CN
+"Maria Pure of Heart","玛利亚纯洁之心医院",zh-CN
+"Marigold","万寿菊",zh-CN
+"Marine Heavy Helmet","陆战队重盔",zh-CN
+"Marine Light Helmet","陆战队轻盔",zh-CN
+"Marine Light Helmet (Blacked Out)","陆战队轻盔（涂黑）",zh-CN
+"Marine Light Instructor Armour","陆战队轻型教员甲",zh-CN
+"Marine Light Sniper Armour","陆战队轻型狙击手甲",zh-CN
+"Marine Medium Helmet","陆战队中盔",zh-CN
+"Mario Kosso","马里奥·科索",zh-CN
+"Maris","怒涛",zh-CN
+"Marisol","马里索尔",zh-CN
+"Marisol Belt","马尔索里带",zh-CN
+"Mark Derren","马克·德伦",zh-CN
+"Markahil","玛卡希尔",zh-CN
+"Marksman","神射手",zh-CN
+"Marlin","枪鱼",zh-CN
+"Marok","啼笑鸟",zh-CN
+"Maroon","栗红",zh-CN
+"Mars","火星",zh-CN
+"Marshal","元帅",zh-CN
+"Marshall Leon","马歇尔·林恩",zh-CN
+"Marshall Madrigal","马歇尔·马德里加尔",zh-CN
+"Marshall Winter","玛莎·温特尔",zh-CN
+"Martel Dress","马特尔 长裙",zh-CN
+"Maru Ebony","丸乌木树",zh-CN
+"Mary Beth Aoyade","玛丽·贝丝·奥亚德",zh-CN
+"Mask","面罩",zh-CN
+"Masked Symptoms","隐蔽症状",zh-CN
+"Mass Driver","电磁炮",zh-CN
+"Master Chief Petty Officer","军士长",zh-CN
+"Master Mode","主控模式",zh-CN
+"Master Modes","主控模式",zh-CN
+"Master Sensitivity","总灵敏度",zh-CN
+"Master Sergeant","上士",zh-CN
+"Master Tracker License Certification","大师级赏金猎人执照",zh-CN
+"Masters of Flight","飞行大师",zh-CN
+"Material Specializations","矿物专精项",zh-CN
+"Matias Devi","马蒂亚斯·提毗",zh-CN
+"Matiese shoes","玛蒂斯 鞋",zh-CN
+"Mauler","重拳",zh-CN
+"Mav Thruster","机动推进器",zh-CN
+"MaxLift","极限抬升",zh-CN
+"MaxLift Tractor Beam","极限抬升 牵引光束",zh-CN
+"MaxOx","蛮牛",zh-CN
+"Mayzay","梅泽餐厅",zh-CN
+"Maze","""迷宫""",zh-CN
+"MC-Pinhead","MC-钉头",zh-CN
+"MCA-mk2 Medium Armor","MCA-mk2 中甲",zh-CN
+"MDC","MDC",zh-CN
+"Mecury Star runner","墨丘利 星际快运船",zh-CN
+"MedGel","医疗凝胶",zh-CN
+"Medical","医疗",zh-CN
+"Medical Clinic","医疗诊所",zh-CN
+"Medical Supplies","医疗用品",zh-CN
+"Medical Supply","医疗用品",zh-CN
+"MedicalUNIT","医疗单元",zh-CN
+"Medium artifact fragment (Flawed)","中型遗物碎片（破损）",zh-CN
+"Medium Jump Point","中型跳跃点",zh-CN
+"MediUnit","医疗单元",zh-CN
+"Medpen","医疗笔",zh-CN
+"Megaflux","巨大流量",zh-CN
+"Megumi Refueling","恩惠加油站",zh-CN
+"Meiko Norwood","梅科·诺伍德",zh-CN
+"Meiko Norwood Memorial","梅科·诺伍德纪念地",zh-CN
+"Mel Ososky","梅尔·奥索斯基",zh-CN
+"Melee Weapon","近战武器",zh-CN
+"Melodic Fields Station","旋律领域站",zh-CN
+"Melrose","梅尔罗斯",zh-CN
+"Melty Dog","芝士热狗",zh-CN
+"memVio Booster Blade","memVio 加速刀片服务器",zh-CN
+"Menarik","美奈鱼",zh-CN
+"Meran Holotable","Meran 全息桌",zh-CN
+"Mercantile","商业",zh-CN
+"Mercenary Guild","雇佣兵公会",zh-CN
+"Mercenary's Guild","雇佣兵公会",zh-CN
+"Merchantman","巴努商船",zh-CN
+"Mercury Star Runner","墨丘利 星际快运船",zh-CN
+"Mercy Hospital","仁慈医院",zh-CN
+"Meredith Douze","梅瑞狄斯·杜泽",zh-CN
+"Merguez Sandwich","梅洛兹三明治",zh-CN
+"Merits","功绩点",zh-CN
+"Mesoplanet","中行星",zh-CN
+"Messer","梅塞尔",zh-CN
+"Metal","金属",zh-CN
+"Metallic Grey","金属灰色",zh-CN
+"Meteor","流星",zh-CN
+"Metis","智谋女神",zh-CN
+"Metro Camo","都市迷彩",zh-CN
+"MG Scrip","雇佣兵公会凭证",zh-CN
+"Michael Callum","迈克尔·卡勒姆",zh-CN
+"Michael Kitano","迈克尔·基塔诺",zh-CN
+"Michael Shaw","迈克尔·肖",zh-CN
+"Michael Shiherlis","迈克尔·施乐士",zh-CN
+"Michael Vicar","迈克尔·维卡尔",zh-CN
+"Microid Battle Suit","微机战斗服-轻型护甲",zh-CN
+"microTech","微科星",zh-CN
+"Microtech Corporate Offices","微科公司办公室",zh-CN
+"Midas Fish","迈达斯金纹鱼",zh-CN
+"Midas Salvage Claw","点金手打捞钳",zh-CN
+"Midnight","暗夜迷彩",zh-CN
+"Midnight Calathea","午夜竹芋",zh-CN
+"Midshipman","准尉",zh-CN
+"Miguello Extraction","米格洛萃取公司",zh-CN
+"Miles Eckhart","迈尔斯·埃克哈特",zh-CN
+"Military Close Support","军用后勤",zh-CN
+"Military Transport","军用运输",zh-CN
+"Militia / Patrol","民兵/巡逻",zh-CN
+"Militia Mobilization Initiative","民兵动员计划",zh-CN
+"Millicent Silverton","米利森特·西尔弗顿",zh-CN
+"Min","凕",zh-CN
+"mineables","可开采物",zh-CN
+"Miner's Horn","矿工角菌",zh-CN
+"Mineral","矿物",zh-CN
+"Miners Amalgamated","矿工联合会",zh-CN
+"Mining","采矿",zh-CN
+"Mining Compound","矿区",zh-CN
+"Mining Consumables","采矿耗材",zh-CN
+"Mining Gadget","采矿小工具",zh-CN
+"Mining Modules","采矿模组",zh-CN
+"Mining Rocks","采矿报",zh-CN
+"Mira Ngo","米拉·恩戈",zh-CN
+"Mira Triolo","米拉·特廖洛",zh-CN
+"Mirage","幻金/蜃景 （涂装/护盾发生器）",zh-CN
+"Mirage Holo-Projector","Mirage 全息投影仪",zh-CN
+"Mirai","未来",zh-CN
+"MISC","武藏",zh-CN
+"Misdemeanor","轻罪",zh-CN
+"misfire","失火",zh-CN
+"Misfit","边缘人",zh-CN
+"missile rack","导弹架",zh-CN
+"Mistwalker","雾行者",zh-CN
+"Mivaldi","米瓦尔迪",zh-CN
+"Mixed Mining","混合矿石",zh-CN
+"MK-4 Frag Grenade","MK-4 破片手榴弹",zh-CN
+"mm","毫米",zh-CN
+"mo.Trader","【待定】mo.Trader",zh-CN
+"mobiGlas","mobiGlas",zh-CN
+"mobiGlas 2.0","mobiGlas 2.0",zh-CN
+"mobiGlas Wrist Mount","mobiGlas 表带",zh-CN
+"Mobile Defense Center","机动防御中心",zh-CN
+"mobyGlass Personal Computers","mobyGlass 个人电脑",zh-CN
+"MOD","摩登青年",zh-CN
+"Modamphetamine","莫达非他命",zh-CN
+"Modern Express Station","摩登快车站",zh-CN
+"Modern Icarus Station","现代伊卡洛斯站",zh-CN
+"Modified","经修改",zh-CN
+"Mogote Aid Shelter","莫格特援助避难所",zh-CN
+"Mogote Marmalade","莫格特果酱",zh-CN
+"MOLE","鼹鼠",zh-CN
+"Molina Mold","莫利纳霉菌",zh-CN
+"Monarch","君主（纯色橙）",zh-CN
+"Monde","蒙德",zh-CN
+"Monitor","瞄准镜",zh-CN
+"Monox","殁氧星",zh-CN
+"Monsoon","季风",zh-CN
+"Moonlight","月光（金属白）",zh-CN
+"Moonlight Sonata","月光奏鸣曲",zh-CN
+"Moores","摩尔斯烟",zh-CN
+"Morningstar","晨星",zh-CN
+"Morozov","莫罗佐夫",zh-CN
+"Morozov-CH","莫罗佐夫-CH",zh-CN
+"Morozov-CH backpack Snowdrift","莫罗佐夫-CH背包 雪地版",zh-CN
+"Morozov-SH","莫罗佐夫-SH",zh-CN
+"Morozov-SH-C","莫罗佐夫-SH-C",zh-CN
+"Morozov-SH-I","莫罗佐夫-SH-I",zh-CN
+"Morozov-SH-S","莫罗佐夫-SH-S",zh-CN
+"MOTH","飞蛾",zh-CN
+"Mountaintop Dune","山巅 沙丘",zh-CN
+"Mountaintop Hazard","山巅 冒险",zh-CN
+"Mountaintop Multitone","山巅 多频",zh-CN
+"Mountaintop Neutral","山巅 素彩",zh-CN
+"Mountaintop Vivid","山巅 魏巍",zh-CN
+"Mouse Sensitivity Curves","鼠标灵敏度曲线",zh-CN
+"MPUV Cargo","MPUV 货运",zh-CN
+"MPUV Personnel","MPUV 载人",zh-CN
+"MPUV Tractor","MPUV 牵引",zh-CN
+"MPUV-1C flight jacket","MPUV-1C 飞行夹克",zh-CN
+"Mr.Souse","索斯先生",zh-CN
+"MRX ""Torrent""","MRX “狂潮”",zh-CN
+"mSCU","mSCU",zh-CN
+"MT DataCenter","微科数据中心",zh-CN
+"MT Planetary Services","微科星球公务部",zh-CN
+"MT Protection Services","微科防卫服务",zh-CN
+"MT SecurityCenter DDV-6","微科安保中心 DDV-6",zh-CN
+"MTC","MTC",zh-CN
+"Mule","骡",zh-CN
+"Multi","混色",zh-CN
+"Multi Operator Targeted Harvester","多操作员定向采集机",zh-CN
+"Multi-Function","多功能",zh-CN
+"multi-particle/wave cannons","多粒子/波能炮",zh-CN
+"Murray Cup","穆雷杯",zh-CN
+"Murray Tower","穆雷塔",zh-CN
+"Musaka Burrito","穆萨卡卷饼",zh-CN
+"Musashi Industrial and Starflight Concern","武藏工业与星航株式会社",zh-CN
+"Musashi Lifestyle Design Unit","武藏生活方式设计单位",zh-CN
+"Muse Simpod","Muse 模拟舱",zh-CN
+"Mushroom Pad Thai","蘑菇炒金边粉",zh-CN
+"Mustang Alpha","野马 阿尔法",zh-CN
+"Mustang Beta","野马 贝塔",zh-CN
+"Mustang Delta","野马 德尔塔",zh-CN
+"Mustang Gamma","野马 伽马",zh-CN
+"Mustang Omega","野马 欧米伽",zh-CN
+"Mustard","芥末绿",zh-CN
+"MuyMuy","常常",zh-CN
+"MVSA","Mvsa Laser Autocannon",zh-CN
+"mX-Shatter rocket","mX-粉碎者火箭",zh-CN
+"mX-SR Ammo","mX-SR 弹药箱",zh-CN
+"Mya","米亚",zh-CN
+"Myondo","米昂多",zh-CN
+"Mythic Horizon","神秘地平线",zh-CN
+"Myuda knife","缪达刀",zh-CN
+"Nadia Padgett","纳迪亚·帕吉特",zh-CN
+"Nakamura Valley Aid Shelter","中村谷援助避难所",zh-CN
+"Nakamura Valley Shelter","中村谷避难所",zh-CN
+"Nala“Bullseye”Govea","“靶心”那拉·戈维亚",zh-CN
+"Narina Lerrem","纳琳娜·勒雷姆",zh-CN
+"Narumi Arai","鸣海·荒井",zh-CN
+"Nas Calloway","内斯·卡洛威",zh-CN
+"Natalya Jesui","娜塔莉娅· 杰苏",zh-CN
+"Natural","天然产物",zh-CN
+"Nautilus","鹦鹉螺",zh-CN
+"NAV","航行",zh-CN
+"Nav-E7 Gadgets","领航-E7 工具",zh-CN
+"Navjumper","跳点探险家",zh-CN
+"Navoi","纳沃伊",zh-CN
+"Navy","海军蓝",zh-CN
+"Navy Surplus","海军军品店",zh-CN
+"NDB-26","NDB-26 Neutron Repeater",zh-CN
+"NDB-28","NDB-28 Neutron Repeater",zh-CN
+"NDB-30","NDB-30 Neutron Repeater",zh-CN
+"NDR","营养密度评级",zh-CN
+"Nebula livery","星云涂装",zh-CN
+"Negligent Homicide","过失杀人",zh-CN
+"Nela bugs","内拉虫",zh-CN
+"Nemec","内梅茨",zh-CN
+"Nemo","尼莫",zh-CN
+"Neograph","新石墨",zh-CN
+"Neon","""霓虹""",zh-CN
+"Neoni helmet","氖鬼 头盔",zh-CN
+"Neptune","海王星",zh-CN
+"Nerriva Alle","纳里瓦·众翼",zh-CN
+"Nes(Nas) Calloway","内斯·卡洛韦",zh-CN
+"Neutron","中子",zh-CN
+"New Austin","新奥斯汀",zh-CN
+"New Babbage","新巴贝奇",zh-CN
+"New Corvo","新科尔沃",zh-CN
+"New Deal","全新交易",zh-CN
+"New Horizon","新视野",zh-CN
+"New Junction","新交界",zh-CN
+"New United","新联合报",zh-CN
+"Newcastle","纽卡斯尔",zh-CN
+"Newdawn","曙光",zh-CN
+"Nexus","奈克瑟斯/内克萨斯/纽链",zh-CN
+"Nick's Mistake","尼克的错误",zh-CN
+"Nicks Cantwell","尼克斯·坎特威尔",zh-CN
+"Nico Theolone","尼科·塞洛隆",zh-CN
+"Night","夜色",zh-CN
+"Night Fall","夜幕降临",zh-CN
+"Night Light","夜幕之光",zh-CN
+"Nightfire","夜之火",zh-CN
+"Nightrunner","夜行者",zh-CN
+"Nightshade","龙葵",zh-CN
+"Nightstalker","夜行者迷彩",zh-CN
+"Niklaus Boone","尼克劳斯·博恩",zh-CN
+"NikNax","【待定】NikNax",zh-CN
+"Nine Tails","九尾",zh-CN
+"Njakte","尼贾克特",zh-CN
+"NN-13","NN-13 Neutron Autocannon",zh-CN
+"NN-14","NN-14 Neutron Autocannon",zh-CN
+"Noble","诺布尔",zh-CN
+"Noble Livery","高尚涂装",zh-CN
+"Noise","噪声场",zh-CN
+"Nolan Acker","诺兰·阿克",zh-CN
+"Nomad","游牧者",zh-CN
+"Nomo grubs","诺莫幼虫",zh-CN
+"Non-Metals","非金属",zh-CN
+"Nora Triolo","诺拉·特奥罗",zh-CN
+"Norfield","诺菲尔德",zh-CN
+"Norman Eager","诺曼·埃格",zh-CN
+"Normstar","北及之星",zh-CN
+"North American Alliance","北美洲联盟",zh-CN
+"Northrock","北境之岩",zh-CN
+"Northrock service group","北境之岩服务团队",zh-CN
+"NorthStar","北极之星",zh-CN
+"Nova","新星",zh-CN
+"Nova Pyrotechnica","新星火工",zh-CN
+"Nova Pyrotechnika","新星烟火",zh-CN
+"NovaRiders","新星骑手",zh-CN
+"Novia","诺维娅",zh-CN
+"Novikov","诺维科夫",zh-CN
+"Novikov Armor","诺维科夫护甲",zh-CN
+"Nox","Nox",zh-CN
+"Nox Kue","Nox Kue",zh-CN
+"NT-999-XV","NT-999-XV",zh-CN
+"NT-999-XVI","NT-999-XVI",zh-CN
+"NT-999-XX","NT-999-XX",zh-CN
+"Nuen Waste Management","努恩废物管理中心",zh-CN
+"Nuiqsut Emergency Shelter","努伊克苏特紧急避难所",zh-CN
+"Nul","纽尔",zh-CN
+"Numerous Clans","众氏族",zh-CN
+"Nutritional Density Rating","营养密度评级",zh-CN
+"NV-TAC","NV-装备",zh-CN
+"Nyman","尼曼",zh-CN
+"Nyx","尼克斯",zh-CN
+"O2 Kiosk 或 Oxygen Kiosk 或 Oxygen Dispenser","补氧站",zh-CN
+"Ob Chimera","奇美拉观测站",zh-CN
+"Oberon","奥伯龙",zh-CN
+"Obscura","暗黑",zh-CN
+"Obsidian","黑曜（金属灰）",zh-CN
+"Ocean Planet","海洋行星",zh-CN
+"Ocellus","眼纹",zh-CN
+"Ochelo","奥提琴",zh-CN
+"Octagon","八边形",zh-CN
+"Odin","奥丁",zh-CN
+"Odin Munitions Corporation","奥丁军火协会",zh-CN
+"Odis Broussard","奥迪斯·布鲁萨德",zh-CN
+"ODOK Jacket","ODOK 夹克",zh-CN
+"Odyssa","奥德萨",zh-CN
+"Odyssey","奥德赛-基底服",zh-CN
+"Odyssey II","奥德赛 II-基底服",zh-CN
+"Office of Imperial Justice","帝国司法局",zh-CN
+"Officer Cadet","准尉",zh-CN
+"OKB Voskhod","OKB 沃斯霍德",zh-CN
+"Old '38","老38",zh-CN
+"Old Jegger","老杰格",zh-CN
+"Olive","橄榄色",zh-CN
+"Olive Harding","奥利弗·哈丁",zh-CN
+"Olivia Hurston","奥利维娅·赫斯顿",zh-CN
+"OLP","激光站",zh-CN
+"Olympia","奥林匹亚",zh-CN
+"Olympus (UEES wreck)","奥林巴斯",zh-CN
+"Olympus Financial","奥林匹斯金融",zh-CN
+"Olympus Principal","奥林匹斯人寿保险",zh-CN
+"Omarof  (16x Telescopic)","奥马洛夫 (16 倍光学)",zh-CN
+"Omega Pro","欧米伽 Pro",zh-CN
+"Omelo","欧梅洛苏打水",zh-CN
+"Omnapoxy","环氧脂",zh-CN
+"Omni Mav Thruster","全向机动推进器",zh-CN
+"Omni Pack","全能餐",zh-CN
+"Omni Thruster","全向式推进器",zh-CN
+"OMNI-AFS-Sapphire","全面集成-蓝宝石",zh-CN
+"OMNI-CFS-Diamond","全面集成金刚石-基底服",zh-CN
+"Omnitrek","全向迷踪",zh-CN
+"On Foot","徒步",zh-CN
+"One Life","唯一生命",zh-CN
+"One Light Cap","唯光 帽子",zh-CN
+"One Light Shirt","唯光 衬衣",zh-CN
+"One Light Undersuit","唯光基底服",zh-CN
+"One Meal' Nutrition Bar (Fried Tofu)","“壹餐”营养棒（煎豆腐味）",zh-CN
+"OP Station Demien","德米恩运作空间站",zh-CN
+"OP.NET","行动者网",zh-CN
+"OpalSky","欧泊空",zh-CN
+"Opera Mushroom","歌剧蘑菇",zh-CN
+"Operating a Stolen Vehicle","操纵偷盗载具",zh-CN
+"Operation Pitchfork","草叉行动",zh-CN
+"Operation Solace","慰藉行动",zh-CN
+"Operation Unilateral Force","单边武力行动",zh-CN
+"Ophelia Vine","欧菲利亚藤",zh-CN
+"Ophos","奥飞斯",zh-CN
+"OpioPen","阿片笔",zh-CN
+"optiCore Avionics","optiCore 航电系统",zh-CN
+"Optics","瞄具",zh-CN
+"Optimal Charge Window","充能绿区",zh-CN
+"Optimal Charge Window Rate","最佳充能窗口充能速率",zh-CN
+"Optimal Charge Window Size","最佳充能窗口大小",zh-CN
+"optiVis VI Specs","optiVis VI 眼镜",zh-CN
+"Opus","奥普斯",zh-CN
+"Oracle","预言",zh-CN
+"Orange","橙色",zh-CN
+"Orange Heron","橙鹭",zh-CN
+"Orbital Defense","轨道安保站",zh-CN
+"Orbital Laser Platform","轨道激光平台",zh-CN
+"Orbital Relay","轨道通信中继卫星",zh-CN
+"Orbital Relay","轨道通讯阵列",zh-CN
+"Orbituary","轨道讣闻站",zh-CN
+"ORC-mkV","ORC-mkV",zh-CN
+"Ore Pod","矿石吊舱",zh-CN
+"OreBit","矿位",zh-CN
+"Oretani","奥瑞塔尼",zh-CN
+"Origin","起源",zh-CN
+"Origin Jumpworks","起源跃动",zh-CN
+"Origin Jumpworks GmbH","起源跃动股份有限公司",zh-CN
+"Original Systems","原初公司",zh-CN
+"Orion","猎户座",zh-CN
+"Orison","奥里森",zh-CN
+"Orison General","奥里森综合医院",zh-CN
+"Orison Hospital","奥里森医院",zh-CN
+"Orison Landing Zone","奥里森着陆区",zh-CN
+"Orm","奥姆",zh-CN
+"Orpheus Horizon","俄耳甫斯地平线号",zh-CN
+"Osha","奥沙",zh-CN
+"Osiris","奥西里斯",zh-CN
+"Oslo Arlington","奥斯陆·阿灵顿",zh-CN
+"Oso","奥索",zh-CN
+"Osoian","奥索安",zh-CN
+"Osoian Hides","奥索安皮革",zh-CN
+"Osprey","鱼鹰",zh-CN
+"Ostin Bouchard","奥斯坦·布沙尔",zh-CN
+"Otoni Syndicate","奥托尼黑帮",zh-CN
+"Ouratite","欧拉特烃",zh-CN
+"Outback","荒蛮",zh-CN
+"Outlaws","不法分子",zh-CN
+"Outpost 54","54号站",zh-CN
+"Outrider","先驱者",zh-CN
+"Outsiders","局外者",zh-CN
+"Overcast","阴雨",zh-CN
+"Overdrive","过载驱动",zh-CN
+"Overdrive Initiative","超速协议",zh-CN
+"Overlord","领主",zh-CN
+"OxyPen","氧素笔",zh-CN
+"Oxytorch","氧炬",zh-CN
+"Oya","欧雅",zh-CN
+"Oza","奥扎橘",zh-CN
+"Oza Neo-Imperial Cuisine","奥扎新帝国美食",zh-CN
+"O’Bannon","奥班南",zh-CN
+"P-52 Merlin","P-52 梅林",zh-CN
+"P-72 Archimedes","P-72 阿基米德",zh-CN
+"P4-AR Ballistic Rifle","P4-AR 实弹步枪",zh-CN
+"P4-AR Iron Sight","P4-AR 金属瞄准器",zh-CN
+"P6-LR Ballistic Sniper Rifle","P6-LR 实弹狙击步枪",zh-CN
+"P8-AR Ballistic Rifle","P8-AR 实弹步枪",zh-CN
+"P8-SC Ballistic Smg","P8-SC 实弹冲锋枪",zh-CN
+"PAB-4 Light Armor","PAB-4 轻甲",zh-CN
+"Pacifica","帕奇菲卡",zh-CN
+"package conveyor","包裹收发机",zh-CN
+"PAF","校准站",zh-CN
+"paladin","圣骑士",zh-CN
+"Paladin Helmet","圣骑士头盔",zh-CN
+"Palatino","帕拉蒂诺",zh-CN
+"Palisade","栅栏",zh-CN
+"Pallas","帕拉斯",zh-CN
+"Pambada knife","帕姆巴达刀",zh-CN
+"Pampero","滂沛罗冷风",zh-CN
+"Pancea","万灵",zh-CN
+"Panova","帕诺瓦",zh-CN
+"Pants","裤子",zh-CN
+"Paradan","【暂定】帕拉丹",zh-CN
+"Paradise Cove","天堂湾",zh-CN
+"Parallax","视差",zh-CN
+"Parallax Rifle","视差 步枪",zh-CN
+"ParaMed","医护宝",zh-CN
+"ParaMed Medical Device","医护宝 医疗设备",zh-CN
+"Parapet","护墙",zh-CN
+"Parasite Replica Helmet","""寄生""复刻头盔",zh-CN
+"Parasite V: Dark Birth","《寄生5：黑暗降生》",zh-CN
+"Parasite V: Dark Birth Replica Helmet","""寄生5: 黑暗降生""复刻头盔",zh-CN
+"Parking Violation","违规停泊",zh-CN
+"Partial Paralysis","局部瘫痪",zh-CN
+"Parvat","帕尔瓦特",zh-CN
+"Passenger Transit","客运",zh-CN
+"Patch City","补丁城",zh-CN
+"Pathfinder","寻路者",zh-CN
+"Patricia Sarafian","帕特丽夏 萨拉菲安",zh-CN
+"Paul Dibly","保罗·迪布利",zh-CN
+"Paul McWaters","保罗·麦克沃特斯",zh-CN
+"Pauline Nesso","宝琳·内索",zh-CN
+"Pegasus","飞马座",zh-CN
+"Pembroke Armor","彭布罗克护甲",zh-CN
+"Pembroke Exploration Suit","彭布罗克探索服",zh-CN
+"Pembroke Exploration Suit RSI Ivory Edition","彭布罗克探索服 RSI象牙白版",zh-CN
+"Pembroke Helmet","彭布罗克头盔",zh-CN
+"People's Ailment","人民病",zh-CN
+"People’s Alliance","人民联盟",zh-CN
+"Pepperoni and Peppers Pizza (Slice)","一片胡椒意大利辣香肠比萨",zh-CN
+"Pepperoni Pizza (Slice)","一片意大利辣香肠比萨",zh-CN
+"Peregrine","游隼",zh-CN
+"Performance","演出",zh-CN
+"Perigree","宝路公司",zh-CN
+"Permafrost","冻土",zh-CN
+"Perry Line","佩里线",zh-CN
+"Perry Line Pact","佩里线条约",zh-CN
+"Persei","英仙星",zh-CN
+"Perseus","英仙座",zh-CN
+"Personal Flare","个人荧光棒",zh-CN
+"personal inventory menu","个人库存菜单",zh-CN
+"Personal Transport","个人运输",zh-CN
+"Personal Transport Vehicle (PTV) (Buggy)","私人交通工具 (PTV) (越野小车)",zh-CN
+"Peter Weathermen","皮特·维瑟曼",zh-CN
+"Petra Ling","佩特拉·玲",zh-CN
+"Petram","佩特拉姆",zh-CN
+"Petrus","彼得鲁斯",zh-CN
+"Petty Officer","中士（参考枪炮中士）",zh-CN
+"Phalanx","方阵",zh-CN
+"Phare's Ape","法尔猿",zh-CN
+"Phill's Fill-Up","菲快满",zh-CN
+"Phillip Xu","飞利浦·徐",zh-CN
+"Phillip Xu Homestead","飞利浦-徐 定居点",zh-CN
+"Pico","皮可",zh-CN
+"Pico the Penguin","企鹅皮可",zh-CN
+"Piconalia","皮可欢庆",zh-CN
+"Piecemeal","零碎",zh-CN
+"Piecemeal Armor","零碎护甲",zh-CN
+"Pike","派克",zh-CN
+"Pike Liberty Ale (Bottle)","利伯蒂啤酒-派克（瓶装）",zh-CN
+"Pilot Light Armor","飞行员轻甲",zh-CN
+"pilot seat","驾驶员座位",zh-CN
+"Pin","别针",zh-CN
+"Pinecone","松果星",zh-CN
+"Ping","回波探测",zh-CN
+"Ping wave","回波",zh-CN
+"Pingala","宾伽罗",zh-CN
+"Pinhead","针头",zh-CN
+"Pink","粉色",zh-CN
+"Pioneer","开拓者/先锋",zh-CN
+"PIP","预瞄点",zh-CN
+"Pippa Broussard","皮帕·布鲁萨德",zh-CN
+"Pips","必事",zh-CN
+"Pirate Light Armor","海盗轻甲",zh-CN
+"Pirates","海盗",zh-CN
+"Pisces","双鱼座",zh-CN
+"Pistol","手枪",zh-CN
+"Pistol Ammo Box","手枪弹药箱",zh-CN
+"Pitambu","皮坦布果",zh-CN
+"Pitman","石工",zh-CN
+"Plain Truth","完全真相",zh-CN
+"Planetary Moon","卫星",zh-CN
+"Plasma","电浆",zh-CN
+"Platform Alignment Facility","平台校准设施",zh-CN
+"Platinum","铂金",zh-CN
+"Platinum Bay","白金湾",zh-CN
+"Plaza","商业区",zh-CN
+"Pleurotus Cornusymphonia (Opera Mushroom)","交响号角菇 (歌剧蘑菇)",zh-CN
+"Pluto","冥王星",zh-CN
+"Point Defense System","点防御系统",zh-CN
+"Point Wain Emergency Shelter","维恩地区紧急避难所",zh-CN
+"Polar","极地",zh-CN
+"Polar Camo","极地迷彩",zh-CN
+"Polaris","北极星",zh-CN
+"Polaris Ironworks","北极星钢工厂",zh-CN
+"Policing","警用",zh-CN
+"Pollux Pants","波洛克斯 长裤",zh-CN
+"polonium","钋",zh-CN
+"Ponos","坡诺斯",zh-CN
+"Pontes","庞特斯",zh-CN
+"Pontrelli Express Shipping","庞特雷尔船运",zh-CN
+"Pork Katsu Sandwich","炸猪排三明治",zh-CN
+"Port Olisar","奥丽莎空间站",zh-CN
+"Port Renatus","雷纳图斯港",zh-CN
+"Port Tressler","特雷斯勒空间站",zh-CN
+"Portfolio","档案集",zh-CN
+"Possession of Class A Controlled Substance","持有 A 级管控物",zh-CN
+"Possession of Class B Controlled Substance","持有 B 级管控物",zh-CN
+"Possession of Class C Controlled Substance","持有 C 级管控物",zh-CN
+"Possession of Prohibited Goods","持有违禁物",zh-CN
+"Possession of Stolen Property","持有偷盗赃物",zh-CN
+"Potassium","钾",zh-CN
+"Power","电力",zh-CN
+"Power Pane","电源面板",zh-CN
+"Power plant","发电机",zh-CN
+"Power Suit","动力服",zh-CN
+"Powerbolt","电力栓",zh-CN
+"PPC Burrito","杂蔬鸡肉烩饭卷饼",zh-CN
+"Prallies","普拉利斯",zh-CN
+"Prasad Naturals","普拉萨德自然食品",zh-CN
+"praseodymium","镨",zh-CN
+"Preacher Armaments","传教士军备",zh-CN
+"Predator","掠食者/捕食者",zh-CN
+"Preferred Security Partner","首席安保合伙人",zh-CN
+"Preserve All Wildlife","全野生物种保护组织",zh-CN
+"PriceRight Wholesale","廉价批发",zh-CN
+"Prim","正装鞋",zh-CN
+"Primary Residence","主要居住地",zh-CN
+"Prime","首府城",zh-CN
+"Prime Punch","拳力一击",zh-CN
+"primo sherm","麻烟",zh-CN
+"Prism","棱镜",zh-CN
+"Prism Shotgun","棱镜 霰弹枪",zh-CN
+"Prison Shiv","监狱小刀",zh-CN
+"Private","列兵",zh-CN
+"private corrections provider","私营狱政供应商",zh-CN
+"Private First Class","一等兵",zh-CN
+"Probe","探测站",zh-CN
+"Processed Food","加工食品",zh-CN
+"Processed Goods","加工品",zh-CN
+"Prohibited Good","违禁物",zh-CN
+"Project Archangel","大天使计划",zh-CN
+"Project Cornerstone","“基石”项目",zh-CN
+"Project Far Star","远星计划",zh-CN
+"Project FarStar","远星计划",zh-CN
+"Project Resurrection","“重生”项目",zh-CN
+"Promenade","休闲街",zh-CN
+"Prospector","勘探者",zh-CN
+"Prota","普罗塔菌",zh-CN
+"Protean","变幻自如",zh-CN
+"ProtLife","生命呵护",zh-CN
+"Protoplanet","原行星",zh-CN
+"ProtSkin Undersuit","原始肌肤基底服",zh-CN
+"Providence Industrial Platform","天意工业平台",zh-CN
+"Providence Surplus","天意军品店",zh-CN
+"Prowler","徘徊者",zh-CN
+"Prowler Utility","徘徊者 多功能",zh-CN
+"Proximity","近程引信式",zh-CN
+"Proximity Assist","接近辅助",zh-CN
+"proximity-based voice chat","【待定】区域语音（功能）",zh-CN
+"PTV","PTV",zh-CN
+"PU","持续性宇宙",zh-CN
+"Puffy Planet","蓬松气态巨行星",zh-CN
+"Pulse","脉冲",zh-CN
+"Pulverizer","粉碎者",zh-CN
+"PureClean","纯净",zh-CN
+"Purifier","净化者",zh-CN
+"PurLyfe system","净生系统",zh-CN
+"Purple","紫色",zh-CN
+"Purple Haze","紫烟",zh-CN
+"PYAM","焰火联合",zh-CN
+"PYAM-FARSTAT","焰联-远程站",zh-CN
+"Pyrite livery","硫铁涂装",zh-CN
+"Pyro","派罗",zh-CN
+"Pyro Crab","派罗蟹",zh-CN
+"Pyro RYT multi-tool","焦焰 RYT 多功能工具",zh-CN
+"Pyrometric Chromalysis","温控色谱熔解法",zh-CN
+"Pyrotechnic Amalgamated","焰火联合",zh-CN
+"Qhire Khartu","奎尔 卡图？",zh-CN
+"Quadracell","四相电池",zh-CN
+"Quadracell Mt","四相电池 Mt",zh-CN
+"Quadracell Mx","四相电池 Mx",zh-CN
+"Quantainium","量子矿",zh-CN
+"quantanium","量子矿",zh-CN
+"Quantanium (Quantainium)","量子矿物",zh-CN
+"Quantum Dampener","量子抑阻装置",zh-CN
+"Quantum Dampening","量子抑阻",zh-CN
+"Quantum Enforcement Device","量子截停装置",zh-CN
+"Quantum Fuel","量子燃料",zh-CN
+"Quantum Route","量子路径",zh-CN
+"Quantum Snare","量子陷阱",zh-CN
+"QuantumBoost","量子突进",zh-CN
+"QuarterDeck","25 号甲板",zh-CN
+"Quartz","石英",zh-CN
+"Quartz SMG","石英 冲锋枪",zh-CN
+"Quasi Civilization","故夕文明",zh-CN
+"Quasi Grazer","故夕食草兽",zh-CN
+"Quell","平息",zh-CN
+"Quest","追逐",zh-CN
+"Quick Cool","快冷",zh-CN
+"Quicksilver","水银",zh-CN
+"QuikFlare","""快闪""荧光棒",zh-CN
+"QuikFlarePro","“快闪”荧光棒高级版",zh-CN
+"Quinton","昆坦",zh-CN
+"Quirinus Tech","奎里努斯科技",zh-CN
+"QV Breaker Station","QV碎岩站",zh-CN
+"QV Planet Services","QV 行星服务公司",zh-CN
+"R&R Rest Stop","R&R 休息站",zh-CN
+"R-11","R-11",zh-CN
+"R6 Pro","R6 Pro",zh-CN
+"R97 Ballistic Shotgun","R97 实弹霰弹枪",zh-CN
+"RAB","远星站",zh-CN
+"Rabat","莱巴特",zh-CN
+"Rabum","拉布姆",zh-CN
+"Rachel Atavan","雷切尔·阿塔万",zh-CN
+"Rachel Lester","雷切尔·莱斯特",zh-CN
+"Racine Chodary","拉辛·乔达里",zh-CN
+"Racing","竞速",zh-CN
+"radar contact","雷达联络",zh-CN
+"radar display","雷达显示器",zh-CN
+"Radegast bar","拉德盖斯特酒吧",zh-CN
+"Radegast Distillery","拉德盖斯特酿酒厂",zh-CN
+"Radegast Gold","拉德盖斯特金",zh-CN
+"Radford Crusader Edition","雷德福 十字军版",zh-CN
+"Radiance","光辉",zh-CN
+"Radiant","辐射",zh-CN
+"Radiation Protection","辐射防护",zh-CN
+"Radiation Protection:","辐射防护：",zh-CN
+"Radiation Scrub Rate","辐射清除率",zh-CN
+"Radiation Scrub Rate:","辐射清除率：",zh-CN
+"Radix","基数",zh-CN
+"RAFT","木筏",zh-CN
+"Railen","锐伦",zh-CN
+"Rambler","漫步者",zh-CN
+"Ramon Coen","罗曼·科恩",zh-CN
+"RAMP Corporation","RAMP 公司",zh-CN
+"Rampart","城墙",zh-CN
+"Randell Engler","兰代尔·英格尔",zh-CN
+"Rangefinder","测距仪",zh-CN
+"RangeFinder Aqua","靶场专家 溶液",zh-CN
+"RangeFinder Arctic","靶场专家 极寒",zh-CN
+"RangeFinder Element","靶场专家 元素",zh-CN
+"RangeFinder Gunmetal","靶场专家 炮铜",zh-CN
+"RangeFinder Sandstone","靶场专家 砂岩",zh-CN
+"Ranger","游骑兵",zh-CN
+"Ranger CV","游骑兵 CV",zh-CN
+"Ranger RC","游骑兵 RC",zh-CN
+"Ranger TR","游骑兵 TR",zh-CN
+"Ranta Dung","兰塔有机粪便",zh-CN
+"Rapid Cool","迅冷",zh-CN
+"Rapid Response","速达救护",zh-CN
+"Rat's Nest","鼠巢空间站",zh-CN
+"Rate Of Fire","射速",zh-CN
+"Rating","防护温度、有效距离",zh-CN
+"Ravager-212 Twin Shotgun","劫掠者-212 双管霰弹枪",zh-CN
+"Raven's Roost","渡鸦栖",zh-CN
+"Rayari","拉亚利",zh-CN
+"Rayari Anvik Research Outpost","拉亚利-安维克研究种植站",zh-CN
+"Rayari Cantwell Research Outpost","拉亚利-坎特韦尔研究种植站",zh-CN
+"Rayari Deltana Research Outpost","拉亚利-德尔塔纳研究种植站",zh-CN
+"Rayari Inc","拉亚利公司",zh-CN
+"Rayari Kaltag Research Outpost","拉亚利-卡尔塔格研究种植站",zh-CN
+"Rayari Livengood Research Outpost","拉亚利-利文古德研究种植站",zh-CN
+"Rayari McGrath Research Outpost","拉亚利-麦格拉思研究种植站",zh-CN
+"Rayari, Inc. Corporate","拉亚利股份有限公司",zh-CN
+"Razor","剃刀",zh-CN
+"Razor EX","剃刀 EX",zh-CN
+"Razor LX","剃刀 LX",zh-CN
+"Razorback","剃刀鲸",zh-CN
+"Re-Authorizer","重新授权",zh-CN
+"RE:","回复：",zh-CN
+"Ready-Up","准备就绪",zh-CN
+"ReadyGrip","把握",zh-CN
+"ReadyMeal (Bean and Rice Burrito)","完备膳食（豆米卷）",zh-CN
+"ReadyMeal (Beef Chunks)","完备膳食（切块牛肉）",zh-CN
+"ReadyMeal (Chicken Dinner)","完备膳食（鸡肉餐）",zh-CN
+"ReadyMeal (Chicken Patty and Noodles)","完备膳食（鸡肉饼配面条）",zh-CN
+"ReadyMeal (Meatball Marinara)","完备膳食（意式肉丸）",zh-CN
+"ReadyMeal (Vegetarian)","完备膳食（素食）",zh-CN
+"Reaper","死神",zh-CN
+"Rear Admiral","少将",zh-CN
+"REC","租赁点券",zh-CN
+"Recco Battaglia","雷科·巴塔利亚",zh-CN
+"Reckless Vehicle Operation","鲁莽驾驶",zh-CN
+"Reclaimer","回收者",zh-CN
+"Reclamation & Disposal","“回收&处理”",zh-CN
+"Reclamation & Disposal Orinth","奥林森回收站",zh-CN
+"Recycled Material Composite","再生复合材料",zh-CN
+"Red","激进",zh-CN
+"Red Alert","红色警戒",zh-CN
+"Red Crossroads Station","红色十字路口站",zh-CN
+"Red Festival","火红节",zh-CN
+"Red Festival Feast Combat Ration","火红节盛宴战斗口粮",zh-CN
+"Red Renew Smoothie","红色复兴冰沙",zh-CN
+"Red Wind Linehaul","红风物流",zh-CN
+"Redeemer","救赎者",zh-CN
+"Redfin Energy Modulator","红鳍能量调制器",zh-CN
+"RediMake","即成",zh-CN
+"Redwood","红杉色",zh-CN
+"Reedy","里迪",zh-CN
+"reg-tag","注册标签",zh-CN
+"Regal Luxury Rentals","君威豪华租赁",zh-CN
+"Regal-CS1 Helmet","君权-CS1 头盔",zh-CN
+"Regalia","王权",zh-CN
+"Regen","再生",zh-CN
+"Regeneration","重生",zh-CN
+"Regulus","雷古勒斯",zh-CN
+"Reign","主宰",zh-CN
+"Reisse","瑞斯",zh-CN
+"rel.","相对值(速度/加速度/坐标)",zh-CN
+"Relentless","无情",zh-CN
+"Reliance","信任",zh-CN
+"Reliant","信赖",zh-CN
+"Reliant Kore","信赖 基础",zh-CN
+"Reliant Mako","信赖 新闻",zh-CN
+"Reliant Sen","信赖 科考",zh-CN
+"Reliant Tana","信赖 武装",zh-CN
+"REM","雷姆",zh-CN
+"REM/s","雷姆 / 秒",zh-CN
+"remote asteroid base","边远小行星基地",zh-CN
+"Remote Turret","遥控炮塔",zh-CN
+"Renegade Cargo vest","叛逆货物马甲",zh-CN
+"Renegade Cut vest","叛逆伤口马甲",zh-CN
+"Renegade Racing vest","叛逆狂飙马甲",zh-CN
+"Reno work vest","雷诺工装背心",zh-CN
+"Renovar","革新",zh-CN
+"Repair","维修",zh-CN
+"Repeater","速射炮",zh-CN
+"Republic of One","第一共和",zh-CN
+"Rescue of Esther Hurston","艾希尔·赫斯顿救援行动",zh-CN
+"Rescue Required","需要救援",zh-CN
+"Resistance","抗性",zh-CN
+"Resisting Arrest","拒捕",zh-CN
+"Resolu","决断",zh-CN
+"Resource Drive","资源动员",zh-CN
+"Rest & Relax","休息&放松",zh-CN
+"Restricted Area","管制区域",zh-CN
+"Resurgera","瑞舒吉拉",zh-CN
+"Retaliator","报复者",zh-CN
+"Retaliator Base","报复者",zh-CN
+"Retaliator Bomber","报复者 轰炸",zh-CN
+"Retro Thruster","制动推进器",zh-CN
+"Revel & York","狂欢&约克",zh-CN
+"Revenant Pod","亡魂果荚",zh-CN
+"Revenant Tree","亡魂树",zh-CN
+"Revenant Tree Pollen","亡魂树花粉",zh-CN
+"Revere","崇敬",zh-CN
+"Reverie AR Lens","Reverie AR 眼镜",zh-CN
+"Rey Esteban","雷伊·埃斯特班",zh-CN
+"Reyes Finley Hurston","雷耶斯·芬利·赫斯顿",zh-CN
+"Reyes Ling","雷耶斯·玲",zh-CN
+"Reza's Landing","内扎平台",zh-CN
+"Rhetor","瑞特尔",zh-CN
+"Rhetor Raider","瑞特尔突击者队",zh-CN
+"ribbon for Valor","勇气绶带",zh-CN
+"Riccite","愈金",zh-CN
+"Rick 'Shady' Milligan","瑞克""暗影""米利甘",zh-CN
+"Ridgely","山岭",zh-CN
+"Ridgewalker","山脊行者",zh-CN
+"Rifle Ammo Box","步枪弹药箱",zh-CN
+"Rifle Green","步枪绿",zh-CN
+"Rihlah","力拉/利拉",zh-CN
+"Riker Memorial Spaceport","瑞克纪念空港",zh-CN
+"Rime","白霜",zh-CN
+"Ringaling","叮当饼干",zh-CN
+"Ripper","开膛手",zh-CN
+"RipTops","大地撕裂",zh-CN
+"Road Roller","罗德·罗勒",zh-CN
+"Roberts Space Industries","罗伯茨太空工业",zh-CN
+"Rockslide","岩滑",zh-CN
+"Rod's Fuel 'N Supplies","路德补给站",zh-CN
+"Rogue Planet","流浪行星",zh-CN
+"Roisin","罗西",zh-CN
+"roll Thruster","滚转推进器",zh-CN
+"Ros Biollo","罗斯·比奥罗",zh-CN
+"Rosenblum","罗森布鲁姆",zh-CN
+"Rosenblum Reclamation","罗森布鲁姆改造公司",zh-CN
+"Ross Biollo","罗斯·比奥罗",zh-CN
+"Rotational Thruster","旋转推进器",zh-CN
+"Rothman's Ginger Lime","罗斯曼生姜青柠水",zh-CN
+"Rothman's Rhubarb and Honey","罗斯曼大黄蜂蜜水",zh-CN
+"Rough & Ready","狂勇帮",zh-CN
+"Roughneck","莽夫",zh-CN
+"RoundOff","""四舍五入""",zh-CN
+"Roussimoff Rehabilitation Systems","努西莫夫复原系统",zh-CN
+"Roustabout","码头工号",zh-CN
+"Rowena Dulli","罗维娜·杜丽",zh-CN
+"Roxaphen","咯沙芬",zh-CN
+"Royal Regen","皇家再生",zh-CN
+"Rpel","击退",zh-CN
+"RS-Barrier","RS-屏障",zh-CN
+"RS1 Odysey Spacesuits","RS1 奥德塞 太空服",zh-CN
+"RSI Default JetPack","RSI 默认助推喷口",zh-CN
+"RSI Graphite Edition","RSI 石墨黑版",zh-CN
+"RSI Ivory Edition","RSI 象牙白版",zh-CN
+"RSI Sunburst Edition","RSI 日出红版",zh-CN
+"Ruben Pardue","鲁本·帕度",zh-CN
+"Rubidium","铷",zh-CN
+"Rufus Dunbar","鲁弗斯·邓巴",zh-CN
+"Ruin Station","废墟空间站",zh-CN
+"Rumford","伦福德",zh-CN
+"Rush","突进",zh-CN
+"RUSH CONTRACT","加急合约",zh-CN
+"Rust","锈蚀",zh-CN
+"Rust Society","锈红协会",zh-CN
+"Rustville","锈迹镇",zh-CN
+"Ruto","鲁托",zh-CN
+"Rytif","里提夫",zh-CN
+"S-1132","S-1132",zh-CN
+"S-38 Ballistic Pistol","S38 实弹手枪",zh-CN
+"S71 Assault Rifle","S71 突击步枪",zh-CN
+"Sabine","萨宾",zh-CN
+"Sabine Flight Suit","萨宾飞行服",zh-CN
+"Sabir","【暂定】萨比尔",zh-CN
+"Sabotage","恶意破坏",zh-CN
+"Sabre","军刀",zh-CN
+"Sabre Comet","军刀 彗星",zh-CN
+"Sabre Firebird","军刀 火鸟",zh-CN
+"Sabre Peregrine","军刀 游隼",zh-CN
+"Sabre Raven","军刀 渡鸦",zh-CN
+"Sadaryx","萨达瑞晶",zh-CN
+"Safehab","安居",zh-CN
+"SafeTow","安全牵引",zh-CN
+"Sag Paneer Combat Ration","萨格芝士战斗口粮",zh-CN
+"Saga Datasystems","萨迦数据系统",zh-CN
+"Sage","鼠尾草",zh-CN
+"Sagebrush","三尺艾",zh-CN
+"Sail Casia","船帆芋",zh-CN
+"Saisei","祭星",zh-CN
+"Sakura Sun","樱日集团",zh-CN
+"Sal Whitley","萨尔·惠特利",zh-CN
+"Saldynium","烁迪银",zh-CN
+"Salluq","萨洛克",zh-CN
+"Salvaged Skull","残颅",zh-CN
+"Salvation","拯救/救赎",zh-CN
+"Salvo Frag Pistol","齐射 碎片手枪",zh-CN
+"Sam Besser","萨姆·贝瑟",zh-CN
+"Samark","萨玛克",zh-CN
+"Samoht Rhine","萨摩特·莱因",zh-CN
+"Samson and Sons Salvage Center","参孙父子回收站",zh-CN
+"San'tok.yāi","桑托起亚",zh-CN
+"Sanctuary","庇护",zh-CN
+"Sand Nomads","沙漠牧民",zh-CN
+"Sand Wave","沙浪",zh-CN
+"Sander Freelin","桑达·弗里林",zh-CN
+"Sandstone","砂岩",zh-CN
+"Sandstorm","沙暴",zh-CN
+"Sangar Helmet","战壕 头盔",zh-CN
+"Sarilus","沙鲁斯",zh-CN
+"Sarrab","萨拉布",zh-CN
+"Sasha McKai","萨沙·麦凯尔",zh-CN
+"Sasha McKail","萨沙·麦凯尔",zh-CN
+"Sasha Rust","萨沙·罗斯特",zh-CN
+"Sashi Michaels","萨西·迈克尔斯",zh-CN
+"Saskia","萨斯基亚",zh-CN
+"Sataball","萨塔球",zh-CN
+"Saturn","土星",zh-CN
+"Saurian","蜥蜴",zh-CN
+"Savior","洞察",zh-CN
+"savrilium","萨维里金属",zh-CN
+"Sawtooth Combat Knife","锯齿 战术匕首",zh-CN
+"SC","星际公民",zh-CN
+"SC-1 LIDAR Grenade","SC-1 光达手榴弹",zh-CN
+"Scaleweave Undersuit","鳞纹基底服",zh-CN
+"Scalpel Ballistic Sniper Rifle","解剖刀 实弹狙击步枪",zh-CN
+"Scarlet","猩红色",zh-CN
+"Scattergun","霰弹炮",zh-CN
+"Schui","舒伊",zh-CN
+"Schwester","姐妹星",zh-CN
+"Science and Technology Committee","科学与技术委员会",zh-CN
+"Scimitar","弯刀",zh-CN
+"SCM","战斗",zh-CN
+"Scorch","焦炙",zh-CN
+"Scorpius","天蝎座",zh-CN
+"Scorpius Antares","天蝎座 蝎心",zh-CN
+"Scott Childress","斯科特·柴尔德雷斯",zh-CN
+"Scott Hammell","斯科特·哈梅尔",zh-CN
+"Scottie Bressler","斯科蒂·布雷斯勒",zh-CN
+"Scourge Railgun","天灾 电磁炮",zh-CN
+"Scout","侦查",zh-CN
+"Scrap","废料",zh-CN
+"Screaming Galsons","尖啸加尔森家族",zh-CN
+"Screwdriver","螺丝起子",zh-CN
+"ScrubClean","清刷",zh-CN
+"SCU","标准货物单位",zh-CN
+"Scythe","死镰",zh-CN
+"Seagreen","海绿色",zh-CN
+"Seal Corporation","密封公司",zh-CN
+"Seal Defense Tech","密封防御科技",zh-CN
+"Sean Halloway","肖恩·哈洛韦",zh-CN
+"Sean Nazawa","肖恩·纳泽瓦",zh-CN
+"Seanut","海豆",zh-CN
+"Search and Rescue","搜寻救援",zh-CN
+"seat","座椅",zh-CN
+"Second Life Undersuit","第二人生基底服",zh-CN
+"SecSysHack","SecSysHack",zh-CN
+"Section Chief","地区厅长",zh-CN
+"Securehyde","安全隐蔽",zh-CN
+"Securescreen","安全屏障",zh-CN
+"Secureshield","安全护盾",zh-CN
+"Security Agent","安保代理人",zh-CN
+"Security Associate","安保助理",zh-CN
+"Security Depot Huston-1","赫斯顿一号安保站（布拉曼哨所）",zh-CN
+"Security Depot Lyria-1","莉瑞雅安保站",zh-CN
+"Security Partner","安保合伙人",zh-CN
+"Security Post Criska","克里斯卡安保站",zh-CN
+"Security Post Dipur","迪普尔安保站",zh-CN
+"Security Post Kareah","加利亚安保空间站",zh-CN
+"Security Post Lespin","莱斯平安保站",zh-CN
+"Security Post Moluto","莫鲁托安保站",zh-CN
+"Security Post Opal","欧珀安保站",zh-CN
+"Security Post Prashad","普拉沙德安保站",zh-CN
+"Security Post Thaquray","塔库赖安保站",zh-CN
+"Security Post Wan","万安保站",zh-CN
+"Security Specialist","安保专家",zh-CN
+"Sedulity","奋勉",zh-CN
+"Seeker","追踪者",zh-CN
+"Selby Arctic","塞尔比 极寒",zh-CN
+"Selby Black","塞尔比 黑色",zh-CN
+"Selby Desert","塞尔比 土黄色",zh-CN
+"Selene","塞勒涅",zh-CN
+"SELF-LAND","自属之地",zh-CN
+"Senior Security Agent","高级安保代理人",zh-CN
+"Sensible Synthworld Amendment","合理化合成世界修正案",zh-CN
+"Sensitivity All","所有灵敏度",zh-CN
+"Serac","冰塔",zh-CN
+"Seraphim Station","炽天使空间站",zh-CN
+"Seraphim Systems","六翼天使系统",zh-CN
+"Serenity","宁静",zh-CN
+"Sergeant","中士",zh-CN
+"Sergeant Major","军士长",zh-CN
+"Set As Destination","设为目的地",zh-CN
+"SF7B","SF7B Ballistic Gatling",zh-CN
+"SF7E","SF7E Laser Cannon",zh-CN
+"Shackleton","沙克尔顿",zh-CN
+"Shadow Livery","暗影涂装",zh-CN
+"Shadowfall","影落镇",zh-CN
+"Shady Glen Farms","荫谷农场",zh-CN
+"Shallow Fields Station","轻浅田野站",zh-CN
+"Shallow Frontier Station","浅边站",zh-CN
+"Shana","莎娜",zh-CN
+"Sharud","沙鲁德",zh-CN
+"Shattered Blade","碎刃帮",zh-CN
+"Shawn Walker","肖恩·沃克",zh-CN
+"Shelly Ashburn","雪莉·阿什本",zh-CN
+"Shepherd's Rest","牧人驿站",zh-CN
+"Sherman","谢尔曼",zh-CN
+"Sheut","心影",zh-CN
+"Shield Banu","巴努护盾",zh-CN
+"Shield emitter","护盾发射器",zh-CN
+"Shield generators","护盾生成器",zh-CN
+"Shield Health","护盾量",zh-CN
+"Shifting Sands","流沙",zh-CN
+"Shimmer","微光",zh-CN
+"ship","飞船",zh-CN
+"Shirts","衬衫",zh-CN
+"Shiv","锈刃",zh-CN
+"Shoel","秀儿",zh-CN
+"Shoes","鞋子",zh-CN
+"Shopping Kiosk","购物终端",zh-CN
+"Short Range Patrol Fighter","短途巡逻战斗机",zh-CN
+"Shorvu","肖尔武",zh-CN
+"Showdown","决胜之辩/舰船大对决",zh-CN
+"Shoyu Lapsha","炸酱面",zh-CN
+"Shrimp Typhoon Burrito","旋风虾卷",zh-CN
+"Shroud","护罩",zh-CN
+"Shroud livery","遮蔽涂装",zh-CN
+"Shubin Interstellar","舒宾星际",zh-CN
+"Shubin Interstellar Contractor Services","舒宾星际合同承包服务",zh-CN
+"Shubin Mining Facility SAL-2","舒宾矿业设施 SAL-2",zh-CN
+"Shubin Mining Facility SAL-5","舒宾矿业设施 SAL-5",zh-CN
+"Shubin Mining Facility SCD-1","舒宾采矿设施 SCD-1",zh-CN
+"Shubin Mining Facility SM0-10","舒宾矿业设施 SM0-10",zh-CN
+"Shubin Mining Facility SM0-13","舒宾矿业设施 SM0-13",zh-CN
+"Shubin Mining Facility SM0-18","舒宾矿业设施 SM0-18",zh-CN
+"Shubin Mining Facility SM0-22","舒宾矿业设施 SM0-22",zh-CN
+"Shubin Processing Facility SPAL-12","舒宾加工设施 SPAL-12",zh-CN
+"Shubin Processing Facility SPAL-16","舒宾加工设施 SPAL-16",zh-CN
+"Shubin Processing Facility SPAL-21","舒宾加工设施 SPAL-21",zh-CN
+"Shubin Processing Facility SPAL-3","舒宾加工设施 SPAL-3",zh-CN
+"Shubin Processing Facility SPAL-7","舒宾加工设施 SPAL-7",zh-CN
+"Shubin Processing Facility SPAL-9","舒宾加工设施 SPAL-9",zh-CN
+"Shubin Processing Facility SPMC-1","舒宾加工设施 SPMC-1",zh-CN
+"Shubin Processing Facility SPMC-10","舒宾加工设施 SPMC-10",zh-CN
+"Shubin Processing Facility SPMC-11","舒宾加工设施 SPMC-11",zh-CN
+"Shubin Processing Facility SPMC-14","舒宾加工设施 SPMC-14",zh-CN
+"Shubin Processing Facility SPMC-3","舒宾加工设施 SPMC-3",zh-CN
+"Shubin Processing Facility SPMC-5","舒宾加工设施 SPMC-5",zh-CN
+"Shutter Flashbang","快门 闪光弹",zh-CN
+"Sidekick Shuttles","小帮手快运",zh-CN
+"Sienna","褐色",zh-CN
+"Sila Karf","西拉·卡夫",zh-CN
+"Silas Koerner","塞拉斯·克尔纳",zh-CN
+"Silicon","硅",zh-CN
+"Silnex","高级航空陶瓷",zh-CN
+"Silver","银色",zh-CN
+"Silver Spark","银色火花",zh-CN
+"Silverton","西弗顿",zh-CN
+"Silverton Campsite","西尔弗顿露营地",zh-CN
+"Silvio Halbrook","席尔维奥·霍尔布鲁克",zh-CN
+"Simon Totland","西蒙·托兰德",zh-CN
+"Simone Visconti","西蒙·维斯孔蒂",zh-CN
+"Simoom Livery","西蒙风涂装",zh-CN
+"Simpods Pals","模拟舱伙伴",zh-CN
+"Sinkhole Backpack","沉洞背包",zh-CN
+"Sion","西翁",zh-CN
+"Sion Compensator","西翁枪口补偿器",zh-CN
+"Siren","警笛",zh-CN
+"Sizi","西齐",zh-CN
+"Skellig","斯凯利格",zh-CN
+"Skinner","剥皮者",zh-CN
+"Skiv","斯齐夫",zh-CN
+"Skullcrusher","碎颅者",zh-CN
+"Skutters","射手",zh-CN
+"Sky","天蓝色",zh-CN
+"Sky Palm","天空棕榈",zh-CN
+"Skyhigh City","凌空之城",zh-CN
+"Skyline","【待定】全息星图",zh-CN
+"Skyrider","天空骑士",zh-CN
+"SkyWay","天路",zh-CN
+"Slacks","休闲裤",zh-CN
+"SLAM","“冠军”",zh-CN
+"Slate Camo","黑灰迷彩",zh-CN
+"Sleeping Tiger Malt","沉眠猛虎麦芽酒",zh-CN
+"Slicers","切割者",zh-CN
+"Slim Chance Rally","机会渺茫拉力赛",zh-CN
+"Slipstream","尾流",zh-CN
+"Sloma","斯洛玛",zh-CN
+"Slugger Heavy Armor","重炮手重甲",zh-CN
+"SM","星际陆战队",zh-CN
+"Small artifact fragment (Pristine)","小型遗物碎片（完好）",zh-CN
+"Small Jump Point","小型跳跃点",zh-CN
+"Smartgen","智能驱动",zh-CN
+"SMG","冲锋枪",zh-CN
+"Smog Planet","烟雾行星",zh-CN
+"Smokey","“烟雾”",zh-CN
+"Smoltz (Bottle)","斯莫尔茨（瓶装）",zh-CN
+"Smoltz (Pint)","斯莫尔茨 (一品脱)",zh-CN
+"Smoltz Light (Bottle)","斯莫尔茨淡爽（瓶装）",zh-CN
+"Snaggle Protein Stick (Pepper Pepper Pepper)","混搭肉条（三重胡椒风味）",zh-CN
+"Snaggle Stick (New Austin Bold)","混搭肉条（新奥斯汀风味）",zh-CN
+"Snaggle Stick (Original)","混搭肉条（原味）",zh-CN
+"Snaggle Stick (Smoke Daddy)","混搭肉条（烟熏达人风味）",zh-CN
+"Snaggle Stick (Tikoro Bite)","混搭肉条（咽喉痛击风味）",zh-CN
+"Snow Blind","雪盲",zh-CN
+"Snowblind","雪盲",zh-CN
+"Snowfall","降雪",zh-CN
+"Snowpack","雪堆",zh-CN
+"Snub Fighter","舰载战斗机",zh-CN
+"Socoria","索科利亚",zh-CN
+"Sodium","钠",zh-CN
+"Softshell","软壳",zh-CN
+"Sojourn","旅居",zh-CN
+"Sol","太阳系",zh-CN
+"Sol Detox Smoothie","太阳排毒冰沙",zh-CN
+"Sol-III","太阳-III",zh-CN
+"Solanki Platform","索兰奇平台",zh-CN
+"Solar Flare","太阳耀斑",zh-CN
+"Solarflare","太阳耀斑",zh-CN
+"SolEd","星系编辑器",zh-CN
+"Solomon Hurston","所罗门·赫斯顿",zh-CN
+"Something Every Thusday","周二有料",zh-CN
+"Soniclite","微动声波",zh-CN
+"Sonny Pak","桑尼·帕克",zh-CN
+"Sonny's Sham","桑尼的骗局",zh-CN
+"Sootho","索夫",zh-CN
+"Souli","公会",zh-CN
+"Space Cactus - Kavische","太空仙人掌 - 卡维斯彻",zh-CN
+"Space Station","太空站",zh-CN
+"Spaceglobe","太空球",zh-CN
+"Spar Van Miles","斯帕·范·迈尔斯",zh-CN
+"Spar-Tee","斯巴尔T恤",zh-CN
+"SparkFire","星火",zh-CN
+"Sparkjet","火花机",zh-CN
+"Sparkjet Pro","火花机 Pro",zh-CN
+"Sparrer Light Armor","拳斗轻甲",zh-CN
+"Spartan","斯巴达",zh-CN
+"Spearhead","矛头",zh-CN
+"Special Agent","特别探员",zh-CN
+"Special Agent-in-Charge","特别探督",zh-CN
+"Special Operation Formula Combat Ration","特种作战标准战斗口粮",zh-CN
+"Specialist","技术军士",zh-CN
+"Spectre","幽魂",zh-CN
+"Spectrum","光谱",zh-CN
+"Spectrum Spectator","光谱观察家",zh-CN
+"Spiced Protein Stew Combat Ration","五香炖蛋白肉战斗口粮",zh-CN
+"Spicule","刺针",zh-CN
+"Spider","蜘蛛空间站",zh-CN
+"Spike","尖刺",zh-CN
+"Spirit","星灵",zh-CN
+"Spooling","预热",zh-CN
+"Spruce","云杉木色",zh-CN
+"Spyglass","窥镜",zh-CN
+"Sr. Crusader Reservist","资深十字军预备役士兵",zh-CN
+"SRT","打捞修复工具",zh-CN
+"SRV","SRV",zh-CN
+"SS Lighthammer","SS 轻锤",zh-CN
+"Stabilizer","枪口稳定器",zh-CN
+"Stalford (Consolidated Outlands' HQ)","斯塔弗德",zh-CN
+"Stalker","追猎者",zh-CN
+"Stanton","斯坦顿",zh-CN
+"Stanton Experience Tours, Ltd.","斯坦顿印象旅游有限公司",zh-CN
+"Stanton Knights","斯坦顿骑士队",zh-CN
+"Stanton Wildlife Federation","斯坦顿野生动物协会",zh-CN
+"Star Kitten","星空猫",zh-CN
+"Star Kitten Helmet","星空猫 头盔",zh-CN
+"Star Runner","星际快运船",zh-CN
+"Starburn","星焰",zh-CN
+"Starchaser","逐星者",zh-CN
+"Starfarer","星际远航者",zh-CN
+"Starfarer Gemini","星际远航者 双子座",zh-CN
+"Starheart","星心",zh-CN
+"Stark","全力",zh-CN
+"Starlancer","星际枪骑兵",zh-CN
+"Starlifter","星际运输船",zh-CN
+"Starlight","星光",zh-CN
+"Starlight Service Station","星光服务站",zh-CN
+"Starman","二等兵",zh-CN
+"Starman Recruit","列兵",zh-CN
+"Starter","新手船",zh-CN
+"Starwatch!","明星观察室",zh-CN
+"StarWords","星文本工具",zh-CN
+"Steadfast","坚定",zh-CN
+"Steel","银钢",zh-CN
+"Stegman","施特格曼",zh-CN
+"Stella Fortuna","幸运星节",zh-CN
+"Stellate","星状",zh-CN
+"Sterling","纯银 （金属银）",zh-CN
+"Sterling Silver","纯银",zh-CN
+"Sterne Katzen AG Hornisse-36","星夜之猫 AG 霍妮丝-36",zh-CN
+"Sterogen","甾原",zh-CN
+"Steward","管家",zh-CN
+"Stileron","稀钛铁",zh-CN
+"Stims","斯酊姆烟草",zh-CN
+"Stinger","毒刺",zh-CN
+"Stirling","斯特林",zh-CN
+"Stitcher","缝纫机",zh-CN
+"STM","STM 啤酒",zh-CN
+"Stoddard Research Center","斯托达德研究中心",zh-CN
+"Stoic","隐忍",zh-CN
+"Stone Bug","石虫",zh-CN
+"stone bug shell","石虫壳",zh-CN
+"Stoneskin Undersuit","石肤基底服",zh-CN
+"Stop","停滞",zh-CN
+"Stor*All","万可存",zh-CN
+"Stor-All","存储万物",zh-CN
+"Storm","风暴",zh-CN
+"Storm AA","风暴 AA",zh-CN
+"Storm Rider Palm","风暴骑士棕榈",zh-CN
+"Storm Surge","风暴汹涌",zh-CN
+"Stormburst","风爆",zh-CN
+"Stormfall","风暴迷彩",zh-CN
+"Stormwal","风暴鲸",zh-CN
+"Stows","斯托斯",zh-CN
+"Strata","岩层",zh-CN
+"Strata Holosphere","Strata 全息星体仪",zh-CN
+"Stratus","层云",zh-CN
+"Stratus Shopping Center","层云购物中心",zh-CN
+"Straw","稻草黄（存疑）",zh-CN
+"Strike","直接打击式",zh-CN
+"StrikeForce","致命打击",zh-CN
+"Strode","阔步",zh-CN
+"Strog-N-Off Burrito","酸奶油炖肉卷饼",zh-CN
+"Stronger Together","团结就是力量",zh-CN
+"Stronghold","据点",zh-CN
+"Stuck at Olisar","困在奥丽莎",zh-CN
+"Sturgis","斯特吉斯",zh-CN
+"STV","STV",zh-CN
+"Sub-Item","子组件",zh-CN
+"Subcommittee for Internal Appraisal","内务评估小组委员会",zh-CN
+"SubCommittee of Spectrum Approval","光谱审批小组委员会",zh-CN
+"Subcommittee on Commerce & Trade","商业与贸易小组委员会",zh-CN
+"Subcommittee on Expansion & Development","扩张与发展小组委员会",zh-CN
+"Subcommittee on the Internal","内务小组委员会",zh-CN
+"Subgiant","亚巨星",zh-CN
+"Sukoran","斯科拉",zh-CN
+"Suldrath","苏得拉斯",zh-CN
+"Summer Davis","萨默·戴维斯",zh-CN
+"Summit","顶点",zh-CN
+"Sunblock","蔽日",zh-CN
+"SunFire","阳炎",zh-CN
+"Sunflare","耀斑",zh-CN
+"Sunset Berries","日落浆果",zh-CN
+"Sunset Mesa","日落方山",zh-CN
+"Super Jupiter","超级类木行星",zh-CN
+"Super-Earth","超级类地行星",zh-CN
+"Superdrive","超级驱动",zh-CN
+"Superiority","空优机",zh-CN
+"Supersonic","超音速",zh-CN
+"Supersonic Livery","超音速涂装",zh-CN
+"Supervisory Special Agent","特别探司",zh-CN
+"suppress","抑制",zh-CN
+"Supreme","极上帮",zh-CN
+"SureGrip","绝对牵引",zh-CN
+"Sureshot","神准",zh-CN
+"Surestop","必然停滞",zh-CN
+"Surging","喘振",zh-CN
+"Survey ship","勘测船",zh-CN
+"Surveyor","勘测者",zh-CN
+"Survivalist","生存者",zh-CN
+"Suspect Apprehension Certification","罪犯追捕执照",zh-CN
+"Svetlana Gallivan","斯维特拉娜·加里文",zh-CN
+"Swarm","蜂群",zh-CN
+"Swirly Blend","旋涡拼配咖啡",zh-CN
+"Sword of Hope","希望之剑",zh-CN
+"Sword Warlock","剑术师",zh-CN
+"Syang Fabrication","丝扬制造",zh-CN
+"Syang Fabrications","丝扬制造",zh-CN
+"Sylvain Evans","西尔万·埃文斯",zh-CN
+"Synergy","协调",zh-CN
+"Synergy+","协调+",zh-CN
+"SynergySport","协调运动版",zh-CN
+"Synthworld","合成世界",zh-CN
+"Syulen","速伦",zh-CN
+"Tabatha Caster","塔芭塔·卡斯特",zh-CN
+"Taberna","酒馆",zh-CN
+"Tachyon","快子",zh-CN
+"Tacit Suppressor","沉默 枪口消音器",zh-CN
+"Tactical Stealth","战术隐身",zh-CN
+"Taernin","塔尔宁",zh-CN
+"Taiga","寒林",zh-CN
+"Taj Walburn","塔杰·沃尔伯恩",zh-CN
+"Takuetsu","卓越",zh-CN
+"Takuetsu Starships","卓越星船",zh-CN
+"Tal","塔尔",zh-CN
+"Talarine Divide Aid Shelter","塔拉林峡谷援助避难所",zh-CN
+"Talen","利抓",zh-CN
+"Talisman","护符公司",zh-CN
+"Talon","利爪",zh-CN
+"Talon Shrike","利爪 伯劳",zh-CN
+"Talon Weapon Systems","利爪武器公司",zh-CN
+"Talus","岩白",zh-CN
+"Tamdon Plains","坦登平原",zh-CN
+"Tamdon Plains Aid Shelter","坦登平原援助避难所",zh-CN
+"Tammany and Sons","坦姆尼父子",zh-CN
+"Tamsa","坦莎",zh-CN
+"Tamsa Wheel","坦莎·薇尔",zh-CN
+"Tan","黄褐色",zh-CN
+"Tan and Green","棕褐色和绿色",zh-CN
+"Tanga","坦加",zh-CN
+"Tangaroa","坦格罗亚",zh-CN
+"Tanys","塔尼斯",zh-CN
+"Tao’moa","涛墨",zh-CN
+"Tar Pits","焦油坑",zh-CN
+"Taranis","塔拉尼斯",zh-CN
+"Taranite","塔兰导电石",zh-CN
+"Targa","塔尔加",zh-CN
+"Targeting","瞄准",zh-CN
+"Tarsus","塔苏斯",zh-CN
+"TaskForce","特遣",zh-CN
+"Tat'Ko","塔科",zh-CN
+"Tau Plus (4x Telescopic)","陶 Plus (4 倍光学)",zh-CN
+"taverbark pine","塔弗巴克松树",zh-CN
+"Tawny","茶色",zh-CN
+"Taya Wityoung","塔亚·维蒂昂",zh-CN
+"Tayac","塔亚克",zh-CN
+"TBF-4 combat knife","TBF-4 战术匕首",zh-CN
+"TCS-4 Undersuit","TCS-4 基底服",zh-CN
+"Teach's Ship Shop","蒂奇的飞船店",zh-CN
+"Teal","蓝绿色",zh-CN
+"Teasa Spaceport","蒂莎空港",zh-CN
+"Technology","科技产品",zh-CN
+"Technotic","技术通告",zh-CN
+"Tecia ""Twitch"" Pacheco","特西亚·“刺痛”·帕切科",zh-CN
+"Tecia Pacheco","特西亚·帕切科",zh-CN
+"Tecia""Twitch""Pacheco","特西亚·""刺痛""·帕切科",zh-CN
+"Tectonic","构筑",zh-CN
+"Tectonic Livery","构筑涂装",zh-CN
+"Teddy's Playhouse","泰迪的玩具屋",zh-CN
+"Tehachapi","特哈查比",zh-CN
+"Tekaw","特卡夫",zh-CN
+"Telescopic","光学透镜",zh-CN
+"Tellurium","碲",zh-CN
+"Temp Rating","适用温度",zh-CN
+"Temp. Rating","适用温度",zh-CN
+"Temp. Rating:","适用温度：",zh-CN
+"Tempest","暴风雨",zh-CN
+"Tempo","节奏",zh-CN
+"Temporary Contractor","临时承包人",zh-CN
+"Tempt Fate Tankard","挑战命运啤酒杯",zh-CN
+"Tephra Mine","火山灰鱼雷",zh-CN
+"Tepilo","微温",zh-CN
+"Tequila","龙舌兰",zh-CN
+"Terminus","端点星",zh-CN
+"Terra","泰拉",zh-CN
+"Terra Gazette","泰拉公报",zh-CN
+"Terra Liberty Ale (Bottle)","利伯蒂啤酒-泰拉（瓶装）",zh-CN
+"Terra Mills","泰拉磨坊",zh-CN
+"Terra Mills HydroFarm","泰拉磨坊水培种植站",zh-CN
+"Terra Museum of Contemporary Art","泰拉当代艺术博物馆",zh-CN
+"Terraberry","泰拉莓",zh-CN
+"terraforming","地球化改造",zh-CN
+"Terragra","泰拉格拉",zh-CN
+"Terran Tea","泰拉茶",zh-CN
+"Terrapin","水龟",zh-CN
+"Terrence Akari","泰伦斯·阿卡利",zh-CN
+"Terrence Connors","特伦斯·康纳斯",zh-CN
+"Terrence Mally","特伦斯·马利",zh-CN
+"Terrence Naban","特伦斯·纳班",zh-CN
+"Terrestrial Rocky","岩质行星",zh-CN
+"Tesca Halimeade","泰斯卡·哈利米达",zh-CN
+"Tesko Corbin","特斯科·科宾",zh-CN
+"Tessa Banister","泰莎·班尼斯特",zh-CN
+"Test Facility Octagon","八边形测试设施",zh-CN
+"Testudo","龟甲",zh-CN
+"Tevarin","塔维因",zh-CN
+"Tevarin Sovereignty","塔维因主权国",zh-CN
+"Tevarin War Service Marker (Pristine)","塔维因战争服役徽记（完好）",zh-CN
+"Th.us'āng","舒'安",zh-CN
+"Thawort","解冻草",zh-CN
+"The Ark","方舟",zh-CN
+"The Artificial Intelligence Research and Productio","人工智能研究与生产限制法案",zh-CN
+"The Avenger","《复仇者》",zh-CN
+"the Broussards","布鲁萨德家族",zh-CN
+"The Butcher Helmet","屠夫 头盔",zh-CN
+"The Coil","“线圈”",zh-CN
+"The Commons","市民广场",zh-CN
+"The Factory Line","生产线",zh-CN
+"THE FALL OF CALIBAN","卡利班的沦陷",zh-CN
+"The First Terraberry","第一颗泰拉莓",zh-CN
+"The Franklin Flip","富兰克林空翻",zh-CN
+"The Fundamentals of Mining","采矿基础知识",zh-CN
+"the Garden","庭园",zh-CN
+"The Golden Riviera","金碧湾",zh-CN
+"The Guide to Stanton Wildlife","斯坦顿野生动物指南",zh-CN
+"The Million Mile High Club","百万英里俱乐部",zh-CN
+"The Moraine","冰碛帮",zh-CN
+"The Necropolis","墓地",zh-CN
+"The Nest","鸟巢公寓",zh-CN
+"The Nest Apartment","鸟巢公寓",zh-CN
+"The Observist","观察家",zh-CN
+"The Observist Dark","黑暗观察家",zh-CN
+"The Observist Lifestyle","观察家的生活方式",zh-CN
+"The Orphanage","孤儿院",zh-CN
+"The Pit","坑地",zh-CN
+"The Red God","红神星",zh-CN
+"The Rescue of Bastien Nemitz","巴斯蒂安·尼米兹救援行动",zh-CN
+"The Silver Leaf Society","银叶会",zh-CN
+"The Starman's Farewell","太空兵的告别",zh-CN
+"The Yard","庭院",zh-CN
+"Thermal Core","热量核心",zh-CN
+"thermal drift","温漂",zh-CN
+"ThermalFoam","热泡沫塑料",zh-CN
+"thermal drift","温漂",zh-CN
+"Thermax","温度美",zh-CN
+"Thermonatic Deposition","热力沉积法",zh-CN
+"ThermoWeave","热纺",zh-CN
+"Thermyte Concern","铝热公司",zh-CN
+"Theta Pro (8x Telescopic)","希塔 Pro (8 倍光学)",zh-CN
+"This Day in History","历史上的今天",zh-CN
+"Thli","浪涌",zh-CN
+"Thlilye","闪烈",zh-CN
+"Thlūn","思魂",zh-CN
+"Tholo","梭螺",zh-CN
+"Thorby","索比",zh-CN
+"Thorean Basque","索伦·巴斯克",zh-CN
+"Thorium","钍",zh-CN
+"Thorshu","索尔述龙虾",zh-CN
+"Thorshu Grey","索尔述灰白螃蟹",zh-CN
+"Thousand Seas Corporation","千尺深海公司",zh-CN
+"Thrace Pinter","塞雷斯·品特",zh-CN
+"Threshold","阈点",zh-CN
+"Throttle","节流阀",zh-CN
+"Throttle Speed","节流阀反应速度",zh-CN
+"Thrust","“猛冲”",zh-CN
+"Thruster","推进器",zh-CN
+"Thruster Fluctuation","推进器推力波动",zh-CN
+"Thruster Surging","推进器喘振",zh-CN
+"Thrusters","推进器",zh-CN
+"Thumbstick Sensitivity Curves","游戏手柄摇杆灵敏度曲线",zh-CN
+"Thunderbolt","霹雳",zh-CN
+"Thundering Express Station","雷霆快车站",zh-CN
+"Tiber","台博尔（或者提博尔？）",zh-CN
+"Tigerlilly","卷丹",zh-CN
+"Tigersclaw","虎爪",zh-CN
+"Tigo","蒂戈",zh-CN
+"Tilapia Verde Burrito","墨西哥青辣酱罗非鱼卷饼",zh-CN
+"Timberline","林木线",zh-CN
+"Times of Myth","《神秘年代》",zh-CN
+"Timura","提穆拉",zh-CN
+"Tin","锡",zh-CN
+"Tiptop","锋尚快餐",zh-CN
+"Titan","《泰坦》",zh-CN
+"Titania Terraforming","缇坦妮雅星球改造",zh-CN
+"Titanium","钛",zh-CN
+"Title:","主题：",zh-CN
+"Titus Costigan","泰特斯·科斯蒂根",zh-CN
+"To:","收件人：",zh-CN
+"Tobin Expo Center","托宾会展中心",zh-CN
+"Tohil","托希尔",zh-CN
+"Toja","托雅",zh-CN
+"Tokyai","里希拉迅龙",zh-CN
+"Tolo Crusader Edition","托洛 十字军版",zh-CN
+"Tona","托纳",zh-CN
+"Tonk","桶克",zh-CN
+"Too Much Soup","汤太多",zh-CN
+"ToolSafe","工具安全",zh-CN
+"Topside Transfers","头牌运输",zh-CN
+"Torite","托瑞特金属",zh-CN
+"Tormenter","施虐者",zh-CN
+"Torpedo Burrito","鱼雷卷饼",zh-CN
+"Torral Aggregate","扭转集合体",zh-CN
+"Torreele Foodstuffs","托雷雷尔食品",zh-CN
+"Torrent","激流 / 湍流",zh-CN
+"Torreto","特雷托",zh-CN
+"Torrez","托雷斯",zh-CN
+"Torsa","躯干",zh-CN
+"Toshi Aaron","澄志·亚伦",zh-CN
+"Tosko Nunnar","托斯科·努纳尔",zh-CN
+"Touchstone","试金石",zh-CN
+"Toughlife","硬汉人生",zh-CN
+"Tovaroh","托瓦沃",zh-CN
+"Towing Beam","牵引光束",zh-CN
+"Toxic","有毒",zh-CN
+"TPF","TPF",zh-CN
+"Trace pants","寻踪 裤子",zh-CN
+"Tracer Laser Pointer","追踪者 激光指示器",zh-CN
+"Tracker","追踪者",zh-CN
+"Tracker Beginner's Permit Certification","入门赏金猎人执照",zh-CN
+"Tracker License Certification","正式赏金猎人执照",zh-CN
+"Tracker Training Permit Certification","见习赏金猎人执照",zh-CN
+"Tractor Beam","牵引光束",zh-CN
+"Trade & Development Division","贸易&发展司",zh-CN
+"Trade Development Divison (TDD)","贸易与发展司",zh-CN
+"Trafficking of Class A Controlled Substance","贩运 A 级管控物",zh-CN
+"Trafficking of Class B Controlled Substance","贩运 B 级管控物",zh-CN
+"Trafficking of Class C Controlled Substance","贩运 C 级管控物",zh-CN
+"Trafficking of Stolen Property","贩运偷盗赃物",zh-CN
+"Trailblazer Boots","先驱 靴子",zh-CN
+"Tram","电车城",zh-CN
+"Tram & Myers Mining","泰姆&迈尔斯矿站",zh-CN
+"Transitionalist Party","变革党",zh-CN
+"Travel Safety Advisory System","旅游安全预警系统",zh-CN
+"Traveler Rentals","旅行者租赁",zh-CN
+"Travis Reese","特拉维斯·里斯",zh-CN
+"Treadlight Shoes","格纹 鞋子",zh-CN
+"Trekker Boots","陲客靴",zh-CN
+"Tremaine's Last Stand","特雷曼的临终奋击",zh-CN
+"Trenta","特伦塔",zh-CN
+"Trespassing (First Degree)","擅闯 (一级)",zh-CN
+"Trespassing (Second Degree)","擅闯 (二级)",zh-CN
+"Trevor Basque","特雷弗 · 巴斯克",zh-CN
+"Tribunal","裁判所/法庭",zh-CN
+"Trident Attack Systems","三叉戟之击",zh-CN
+"Triggerfish","扳机鱼节",zh-CN
+"Tripledown","三重击",zh-CN
+"Trireme S","三桨船",zh-CN
+"Trise","特瑞兹",zh-CN
+"Trise Sling","特瑞兹吊索",zh-CN
+"Tristan Blair","崔斯坦·布莱尔",zh-CN
+"TriStar Private Intelligence","三星私人情报局",zh-CN
+"TroMag","疾磁",zh-CN
+"Trommel","滚筒筛",zh-CN
+"Trooper","列兵",zh-CN
+"Trooper First Class","一等兵",zh-CN
+"TruBarrier","真实屏障",zh-CN
+"TrueDef-Pro","真实防御-Pro 轻型护甲",zh-CN
+"TruHold","实握",zh-CN
+"TS-2","TS-2",zh-CN
+"Tuiping","褪萍",zh-CN
+"Tuiping Livery","褪萍涂装",zh-CN
+"Tulsi","图尔西",zh-CN
+"Tumbril","盾博尔",zh-CN
+"Tumbril Land Systems","盾博尔地面系统",zh-CN
+"Tuna Salad Sandwich","金枪鱼沙拉三明治",zh-CN
+"Tundra","冻原",zh-CN
+"Tungsten","钨",zh-CN
+"Turbodrive","涡轮驱动",zh-CN
+"Turing's Stop","图灵小站",zh-CN
+"Turkey Sandwich","火鸡三明治",zh-CN
+"Turret","炮塔",zh-CN
+"Turret Aim Pitch","炮塔瞄准俯仰",zh-CN
+"Tuserac","图瑟拉克科",zh-CN
+"Tuserac Plena","图瑟拉克重瓣花 (帝王花)",zh-CN
+"Tussock","【暂定】塔索克",zh-CN
+"Tuvic","杜维克",zh-CN
+"Tuvois","图沃瓦",zh-CN
+"Twilight","暮光色",zh-CN
+"Twitch","“刺痛”",zh-CN
+"Twotone","双色釉",zh-CN
+"Twyn's Sandwiches","吐温三明治",zh-CN
+"TY MOYO","泰·莫约",zh-CN
+"Tyche","命运女神",zh-CN
+"Tyger (Project Purple)","数字虎（紫色计划）",zh-CN
+"Tyler Design & Tech","泰勒设计与技术",zh-CN
+"Type","类型",zh-CN
+"Tyrol","蒂罗尔",zh-CN
+"Tyros white synth-leather jacket","泰罗斯 白色合成革夹克",zh-CN
+"Uana Catavilla","乌阿纳·卡塔维拉",zh-CN
+"Ubaid","乌拜德",zh-CN
+"UDS-2943-01-22","UDS-2943-01-22",zh-CN
+"UEC","联合地球信劵",zh-CN
+"UEE","地球联合帝国",zh-CN
+"UEE 6th Platoon Medal (Worn)","UEE 六排勋章（磨损）",zh-CN
+"UEE Advocacy","UEE 督导局",zh-CN
+"UEE Army","UEE 陆军",zh-CN
+"UEE Civic Center","UEE 市政中心",zh-CN
+"UEE Diplomatic Corps","UEE 外交使团",zh-CN
+"UEE Disaster Response Team","UEE 灾难反应小组",zh-CN
+"UEE Marines","UEE 海军陆战队",zh-CN
+"UEE Merchant Navy","UEE 商人海军联盟",zh-CN
+"UEE Navy","UEE 海军",zh-CN
+"UEE Planetary Development Bureau","UEE 行星发展局",zh-CN
+"UEE Senate","UEE 参议院",zh-CN
+"UEES Achilles","UEES 阿喀琉斯",zh-CN
+"UEES Ashton","UEES 阿什顿",zh-CN
+"UEES Barbary","UEES 巴巴里",zh-CN
+"UEES Bengal","UEES 孟加拉",zh-CN
+"UEES Cabrebald","UEES 卡布雷巴尔",zh-CN
+"UEES Cestus","UEES 切斯特斯",zh-CN
+"UEES Cheyenne Mountain","UEES 夏延山",zh-CN
+"UEES Chimera","UEES 奇美拉",zh-CN
+"UEES Croshaw","UEES 克罗肖",zh-CN
+"UEES Drago","UEES 德拉戈",zh-CN
+"UEES Dragonet","UEES 小龙",zh-CN
+"UEES Eagle's Talon","UEES 鹰爪",zh-CN
+"UEES Elizabeth Cahillier","UEES 伊丽莎白·卡希利尔",zh-CN
+"UEES Enyo","UEES 厄倪俄",zh-CN
+"UEES Flyssa","UEES 弗利萨",zh-CN
+"UEES Garibaldi","UEES 加里巴第",zh-CN
+"UEES Gauntlet","UEES 铁拳",zh-CN
+"UEES Gemini","UEES 双子座",zh-CN
+"UEES Gilchrist","UEES 吉尔克里斯特",zh-CN
+"UEES Gliberti","UEES 格里伯蒂",zh-CN
+"UEES Hammerhead","UEES 锤头鲨",zh-CN
+"UEES Idirs","UEES 伊德里斯",zh-CN
+"UEES Javelin","UEES 标枪",zh-CN
+"UEES Knifefish","UEES 刀鱼",zh-CN
+"UEES Krugeri","UEES 克鲁格",zh-CN
+"UEES Leviathan","UEES 利维坦",zh-CN
+"UEES Nautilus","UEES 鹦鹉螺",zh-CN
+"UEES Nephele","UEES 涅斐勒",zh-CN
+"UEES Olympus","UEES 奥林匹斯",zh-CN
+"UEES Orpheus Horizon","UEES 奥菲斯地平线",zh-CN
+"UEES Paul C. Gerwold","UEES 保罗 C. 格沃德",zh-CN
+"UEES Peace","UEES 和平",zh-CN
+"UEES Pegasus","UEES 飞马",zh-CN
+"UEES Polaris","UEES 普拉瑞斯",zh-CN
+"UEES Retribution","UEES 惩戒",zh-CN
+"UEES Stanton","UEES 斯坦顿",zh-CN
+"UEES Tiburo","UEES 提布鲁",zh-CN
+"UEES Torsk","UEES 托尔斯克",zh-CN
+"UEES triggerfish","UEES 扳机鱼",zh-CN
+"UEES Veldor","UEES 韦尔多",zh-CN
+"UEES Vindel","UEES 温德尔",zh-CN
+"UEES War Hammer","UEES 战锤",zh-CN
+"UEES Xanthe Montes","UEES 克珊忒山",zh-CN
+"UltiFlex","最终曲折",zh-CN
+"ULTIMATE IV","《创世纪 4》",zh-CN
+"Ultra Flow","终极对流",zh-CN
+"Ultra-light Ground","超轻型地面载具",zh-CN
+"Ultraflux","终极流量",zh-CN
+"Ultramarine","群青 （金属蓝）",zh-CN
+"Ultraviolet","紫外光",zh-CN
+"Umbra","本影",zh-CN
+"Unauthorized Computer Access","非法接入电脑",zh-CN
+"Unauthorized Interdiction","未授权拦阻",zh-CN
+"unclaimed","无主",zh-CN
+"Uncut SLAM","“冠军”原料",zh-CN
+"Underbarrel","下挂",zh-CN
+"Undersuit","基底服",zh-CN
+"UNE Unification War Medal (Damaged)","UNE 统一战争勋章（损坏）",zh-CN
+"Unification War","统一战争",zh-CN
+"Unified Distribution Management","统一配送管理公司",zh-CN
+"Union","联盟",zh-CN
+"unior Associate","初级助理",zh-CN
+"Unique Ship Signature","飞船出厂签名",zh-CN
+"Unisan Custodial Operations","优尼赞安保公司",zh-CN
+"United Empire of Earth","地球联合帝国",zh-CN
+"United Nations of Earth","地球联合国",zh-CN
+"United Resource Workers","资源工人联合会",zh-CN
+"United Wayfarers Club","旅者联合俱乐部",zh-CN
+"United Workers of Hurston","赫斯顿工人联合会",zh-CN
+"Universal Party","寰宇党",zh-CN
+"University of Jalan","贾兰星大学",zh-CN
+"University of Persei Analytical Research and Quantification","英仙星分析与量化研究大学",zh-CN
+"University of Rhetor","瑞特尔大学",zh-CN
+"University of Saisei","最盛星大学",zh-CN
+"Unknown","未知",zh-CN
+"Unlawful Discharge of a Weapon","非法使用武器",zh-CN
+"Untold Tales","未解之谜",zh-CN
+"UPE (United Planets of Earth) (disbanded)","地球行星联合 （已解散）",zh-CN
+"UPES Arash","UPES 阿拉什",zh-CN
+"UPES Arrowhead","UEES 箭头",zh-CN
+"UPES Bunjil","UPES 班吉尔",zh-CN
+"UPES Perseus","UPES 珀耳修斯",zh-CN
+"Upsiders","上行者",zh-CN
+"Uranium","铀",zh-CN
+"Uranus","天王星",zh-CN
+"UrbEx","城市探险",zh-CN
+"Uriel","乌列尔",zh-CN
+"Ursa","大熊座",zh-CN
+"Ursa Medivac","大熊座 医疗",zh-CN
+"Ursa Rover","大熊座漫游车",zh-CN
+"URW","资工联",zh-CN
+"Utility","工具",zh-CN
+"Utility Item","工具物品",zh-CN
+"Utopia","乌托邦",zh-CN
+"UWC","旅联部",zh-CN
+"Vacha","瓦查",zh-CN
+"Vacuums Kill","真空死亡",zh-CN
+"Vagabond","浪客",zh-CN
+"Valakkar","瓦拉卡蠕虫",zh-CN
+"Vale","威尔",zh-CN
+"Valet Station","接待中心站",zh-CN
+"Valkyrie","女武神/瓦尔基里",zh-CN
+"Valkyrie T-shirt","女武神T恤",zh-CN
+"Vance Superindustrial","万斯超级工业",zh-CN
+"Vanduul","剜度",zh-CN
+"Vanduul Clans","剜度氏族",zh-CN
+"Vanguard","先锋",zh-CN
+"Vanguard Harbinger","先锋 先驱者",zh-CN
+"Vanguard Hoplite","先锋 重装兵",zh-CN
+"Vanguard Sentinel","先锋 哨兵",zh-CN
+"Vanguard Warden","先锋 典狱长",zh-CN
+"Vann","范恩",zh-CN
+"Vanquisher","征服者",zh-CN
+"Vantage Rentals","优越租赁",zh-CN
+"Vapor Block","蒸汽遏制",zh-CN
+"Vaporwear","雾装",zh-CN
+"VariPuck","变化圆盘",zh-CN
+"Vatra","瓦塔拉",zh-CN
+"Vaughn","沃恩",zh-CN
+"Vector","维克托",zh-CN
+"Vector Thruster","矢量推进器",zh-CN
+"Vega","维加",zh-CN
+"Vega Relief Fund","维加救济基金",zh-CN
+"Veggie Dog","素食热狗",zh-CN
+"Veggie Wham","素食温姆堡",zh-CN
+"vehicle","载具",zh-CN
+"Vehicle Loadout Manager","载具装配管理器",zh-CN
+"Vehicle Maintenance Services","【待定】载具维护服务",zh-CN
+"Vehicle Modification App","载具修改应用程序",zh-CN
+"vehicles","载具",zh-CN
+"Vehicular Collision","载具碰撞",zh-CN
+"Veil","面纱",zh-CN
+"Veil Flash Hider","威尔枪口消焰器",zh-CN
+"Venator","猎兵",zh-CN
+"Vendetta","温得塔",zh-CN
+"Vendor Association Conference","供应链协会大会",zh-CN
+"Vent Slug","管道蛞蝓",zh-CN
+"Ventra","文鹊",zh-CN
+"Ventris Crusader Edition","文楚斯 十字军版",zh-CN
+"VentScrub","气爽",zh-CN
+"Venture","探险家",zh-CN
+"Venture Executive","探险家 行政 轻型护甲",zh-CN
+"Venture Helmet","探险家头盔",zh-CN
+"Venture Helmet Carrack Edition","探险家头盔 克拉克版",zh-CN
+"Venture Pathfinder Undersuit","探险家基底服 寻路者",zh-CN
+"Venture Rust Society Undersuit","探险家基底服 锈红协会",zh-CN
+"Venture Voyager Undersuit","探险家基底服 旅行者",zh-CN
+"Venus","金星",zh-CN
+"Vera","实准",zh-CN
+"Verified Freelancer","认证赏金猎人",zh-CN
+"Verified Offworld Laser Technologies","鉴星激光科技",zh-CN
+"Veritas","真理",zh-CN
+"Vermilion","威梅里恩",zh-CN
+"Vermillion Apple","朱红苹果",zh-CN
+"Vernon Tar","维纶·塔尔",zh-CN
+"Veronica Rapt","维罗尼卡·拉普特",zh-CN
+"Versatile","多用途",zh-CN
+"Vertical","垂直",zh-CN
+"Very High-Risk Targets","极高风险目标",zh-CN
+"Vest","马甲",zh-CN
+"Vesta","维斯塔",zh-CN
+"Vestal Water","纯净水",zh-CN
+"Veteran First Responder","资深快速响应者",zh-CN
+"VFG Industrial","VFG 工业",zh-CN
+"Vice","违禁品",zh-CN
+"Vice Admiral","中将",zh-CN
+"Victor Zahid","维克多·扎希德",zh-CN
+"Victoria Hutchins","维多利亚·哈钦斯",zh-CN
+"View Key Bindings","查看按键绑定",zh-CN
+"Viking","维京",zh-CN
+"Vindicator","维护者",zh-CN
+"Violet","紫罗兰色",zh-CN
+"Violet Curcuma","紫姜黄",zh-CN
+"Viper","毒蛇",zh-CN
+"Virgil","维吉尔",zh-CN
+"Virgil Ltd","维吉尔有限公司",zh-CN
+"Virgo","维格",zh-CN
+"Virtual Joystick Mode (Gimbal Lock)","虚拟操纵杆模式 (万向节锁)",zh-CN
+"Virtus","维图斯",zh-CN
+"ViseLock","视定",zh-CN
+"Vison Center","远见中心",zh-CN
+"VitalityPen","活力笔",zh-CN
+"Vivant Shoes","威万鞋",zh-CN
+"viVid display","焕彩显示器",zh-CN
+"VK-00","VK-00",zh-CN
+"VNCL Pulse","剜度 脉冲",zh-CN
+"Void","虚空",zh-CN
+"Voidripper Helmet","虚空撕裂者 头盔",zh-CN
+"VOLT","VOLT",zh-CN
+"Volunteer","志愿者",zh-CN
+"Voodoo","沃度",zh-CN
+"Vortex","涡流",zh-CN
+"Vosca","沃斯卡",zh-CN
+"Voss","沃斯",zh-CN
+"Vox Populi","人民之声",zh-CN
+"Voyage","航程",zh-CN
+"Voyager","旅行者",zh-CN
+"Voyager Bar","远航者酒吧",zh-CN
+"Voyager Direct","航行者直达",zh-CN
+"Vulcan","伏尔甘/火神",zh-CN
+"Vulture","秃鹫",zh-CN
+"Vuur","伏尔",zh-CN
+"Wala","瓦菈",zh-CN
+"Waldron","沃尔顿",zh-CN
+"Waldvol Aerospace","瓦尔德沃尔航天",zh-CN
+"Walesko","威尔士科",zh-CN
+"Wallace Klim","华莱士·克里姆",zh-CN
+"Walleye","大白眼",zh-CN
+"Wally's Bar","沃利酒吧",zh-CN
+"Walton","沃尔顿",zh-CN
+"Wanda Werkheiser","万达·韦克海泽",zh-CN
+"Wanden","典狱长",zh-CN
+"Wanderer","流浪者",zh-CN
+"Wanderer Forest","漂泊者 森林",zh-CN
+"Wanderer livery","流浪者涂装",zh-CN
+"Wanderer Nomad","漂泊者 游牧",zh-CN
+"Wanderer Redline","漂泊者 红线",zh-CN
+"Wanderer Rocky","漂泊者 岩石",zh-CN
+"Ward","城壁",zh-CN
+"Warhawk","战鹰迷彩",zh-CN
+"Waste","垃圾",zh-CN
+"Wastelander","荒原行者",zh-CN
+"Water Bottle","瓶装水",zh-CN
+"Watermelon (Slice)","一片西瓜",zh-CN
+"Wayfare","旅行",zh-CN
+"Waylay Camo livery","伏击迷彩涂装",zh-CN
+"Waylite","威莱特",zh-CN
+"Waylon Vickers","伟伦 · 维克",zh-CN
+"wayward Blade","弹性刀片(服务器)",zh-CN
+"Weapons, Munitions, and Firearms Bureau","武器、弹药与枪械管理局",zh-CN
+"Wear","损耗",zh-CN
+"Weaver Palm","织物棕榈",zh-CN
+"Web","蛛网",zh-CN
+"Weekend Warrior Smoothie","周末勇士冰沙",zh-CN
+"Wei-Tek","未科技",zh-CN
+"Wei-Yin Song","宋伟银",zh-CN
+"Wen/Cassel Propulsion","温/卡塞尔推进",zh-CN
+"Wendell Dopse","温德尔·多普斯",zh-CN
+"Wenren Zhou","周温仁",zh-CN
+"Whamburger","温姆堡",zh-CN
+"Whamburger D-Lux","温姆堡 D-lux",zh-CN
+"Whammer","温姆堡",zh-CN
+"Wheeler's","车夫驿站",zh-CN
+"Whirls","扭扭薯条",zh-CN
+"Whirlwind","旋流",zh-CN
+"Whiskey & Cola","威士忌&可乐",zh-CN
+"Whiskey (Glass)","威士忌 (玻璃杯装)",zh-CN
+"Whiskey Homeward Collection","家乡典藏版威士忌",zh-CN
+"White","白色",zh-CN
+"White Dwarf","白矮星",zh-CN
+"White Heron","白鹭",zh-CN
+"White Lightning","白色闪电",zh-CN
+"White Rose","白玫",zh-CN
+"WhiteHex","六角白",zh-CN
+"WhiteOut","白苍",zh-CN
+"Whitley's Guide","惠特利指南",zh-CN
+"Wide Forest Station","广袤森林站",zh-CN
+"WiDoW","""黑寡妇""",zh-CN
+"Wikelo","维克洛",zh-CN
+"Wikelo Emporium","维克洛百货",zh-CN
+"Wildstar","狂野之星",zh-CN
+"Wilkes & Federman","威尔克斯和费德曼",zh-CN
+"WillsOp","威尔士Op",zh-CN
+"Wilma Ivery","威尔玛·艾佛雷",zh-CN
+"Wilma Ivery Homestead","威尔玛·艾佛雷 定居点",zh-CN
+"Windel Aurelia","温德尔·奥雷利亚",zh-CN
+"Wingman's Hangover","宿醉的僚机",zh-CN
+"Winner’s Circle","胜者环道",zh-CN
+"Winter Star","严冬之星",zh-CN
+"Winter Star EX","严冬之星 EX",zh-CN
+"Winter Star SL","严冬之星 SL",zh-CN
+"Winter Star XL","严冬之星 XL",zh-CN
+"WMF","武管局",zh-CN
+"Wolf","狼式",zh-CN
+"Wolf Point","狼穴",zh-CN
+"Wolf Point Aid Shelter","狼穴援助避难所",zh-CN
+"Woodland","林地迷彩",zh-CN
+"WordBee","文字蜂",zh-CN
+"Worker's Party","工人联会",zh-CN
+"Worklife","职业生涯",zh-CN
+"Worthy Journey","难忘之旅",zh-CN
+"WowBlast Desperado Toy Pistol","惊爆恶徒 玩具手枪",zh-CN
+"Wrecker","搅局者",zh-CN
+"Wuotan","狂暴木",zh-CN
+"X-Forge","X-铸造",zh-CN
+"X1 Base","X1 基础",zh-CN
+"X1 Force","X1 武装",zh-CN
+"X1 Velocity","X1 竞速",zh-CN
+"Xa'Pyen","夏潘合金",zh-CN
+"Xanthule","贤梭",zh-CN
+"XCR Reaction","XCR 反应法",zh-CN
+"Xenia","希尼亚",zh-CN
+"Xeno Threat","异种威胁",zh-CN
+"XenoThreat","异种威胁",zh-CN
+"Xenotrade Authority Acts","外星贸易授权法案",zh-CN
+"Xi'an","希安",zh-CN
+"Xi'an Empire","希安帝国",zh-CN
+"Xi'an Scout","希安侦察机",zh-CN
+"XIAN Quantum Drive","希安 量子驱动器",zh-CN
+"XL1","XL1",zh-CN
+"Xuā'cha","煊煞",zh-CN
+"Xuā'cha Livery","煊煞涂装",zh-CN
+"Xy'kara","希卡拉",zh-CN
+"Yā'mon","亚蒙",zh-CN
+"Yaeger","耶格尔",zh-CN
+"Yakisoba Dog","炒面热狗",zh-CN
+"Yaluk","亚鲁克",zh-CN
+"Yan Linfeld","严·林菲尔德",zh-CN
+"Yang's Place","杨家庄",zh-CN
+"Yann Bostrom","扬·波斯特罗姆",zh-CN
+"Yann Isher","扬·伊舍",zh-CN
+"Yar","亚尔",zh-CN
+"Yeager","耶格尔",zh-CN
+"Yeast Extract and Butter Sandwich","酵母味素黄油三明治",zh-CN
+"Yebira(I,II,III)","矢箙",zh-CN
+"Yela","耶拉",zh-CN
+"Yela's Plain","耶拉平原",zh-CN
+"Yellow","黄色",zh-CN
+"Yellow Core","黄色核心站",zh-CN
+"Yellow Puglath","黄色普格拉斯",zh-CN
+"Yeng’tu","炎图",zh-CN
+"Yenny Shirt","燕妮 衬衫",zh-CN
+"Yilen","亦能",zh-CN
+"Yogi Station","由基站",zh-CN
+"Yorm","约姆公司",zh-CN
+"Yormandi","约曼迪",zh-CN
+"Yubarev ""Deadeye"" Pistol","尤巴列夫手枪",zh-CN
+"Yulin","玉林",zh-CN
+"Yuri Ilyin","尤里·伊林",zh-CN
+"Zack Sanford","扎克·桑福德",zh-CN
+"Zapjet","活力飞机",zh-CN
+"Zelena","【暂定】赛琳娜",zh-CN
+"Zem Kolto","泽姆·科尔托",zh-CN
+"Zenith","天顶",zh-CN
+"Zenith Hall","天顶展厅",zh-CN
+"Zephyr","和风",zh-CN
+"Zero Rush","零度激流",zh-CN
+"Zerua Crusader Edition","泽鲁阿 十字军版",zh-CN
+"Zeta-Prolanide","Z-普罗兰化合物",zh-CN
+"Zeus","宙斯",zh-CN
+"Zeus Exploration Backpack Starscape","宙斯探索服背包 星空版",zh-CN
+"Zeus Exploration Suit","宙斯探索服",zh-CN
+"Zeus Exploration Suit Backpack Solar","宙斯探索服背包 太阳版",zh-CN
+"Zeus Exploration Suit Helmet","宙斯探索服头盔",zh-CN
+"Zinnia","百日菊",zh-CN
+"zip","“滋滋”",zh-CN
+"Zogo knife","祖戈刀",zh-CN
+"Luna","月亮",zh-CN
+"µSCU","µSCU",zh-CN
+"‘Big Rig’ Diaz","“卡车头”迪亚兹",zh-CN

--- a/meta/star-citizen.json
+++ b/meta/star-citizen.json
@@ -1,0 +1,27 @@
+{
+  "id": "star-citizen",
+  "name": "Star Citizen",
+  "description": "Star Citizen terminology glossary, covering ships, weapons, characters, locations, organizations and more. Based on the Star Citizen Chinese localization project at paratranz.cn.",
+  "author": "Star Citizen CN Localization Team",
+  "glossary": "star-citizen",
+  "matches": [
+    "robertsspaceindustries.com",
+    "*.robertsspaceindustries.com",
+    "starcitizen.tools",
+    "*.starcitizen.tools",
+    "paratranz.cn",
+    "https://www.reddit.com/r/starcitizen*",
+    "https://www.reddit.com/r/starcitizen/*",
+    "https://old.reddit.com/r/starcitizen*",
+    "https://old.reddit.com/r/starcitizen/*"
+  ],
+  "langs": [
+    "zh-CN"
+  ],
+  "i18ns": {
+    "zh-CN": {
+      "name": "星际公民",
+      "description": "星际公民术语库，涵盖飞船、武器、角色、地点、组织等专有名词的中文翻译。数据来源于 paratranz.cn 汉化项目。"
+    }
+  }
+}


### PR DESCRIPTION
添加星际公民 (Star Citizen) 中英术语库，包含 4222 条术语。
涵盖飞船、武器、角色、地点、组织等专有名词的中文翻译。
数据来源于 paratranz.cn 汉化项目。