### PR TITLE
feat: 添加《博德之门 3》(Baldur's Gate 3) 中英文核心术语库 (Patch 7)

### DIFF
--- a/glossaries/bg3_zh-CN.csv
+++ b/glossaries/bg3_zh-CN.csv
@@ -1,0 +1,328 @@
+source,target,tgt_lng
+Strength,力量,zh-CN
+Dexterity,敏捷,zh-CN
+Constitution,体质,zh-CN
+Intelligence,智力,zh-CN
+Wisdom,感知,zh-CN
+Charisma,魅力,zh-CN
+Barbarian,野蛮人,zh-CN
+Bard,吟游诗人,zh-CN
+Cleric,牧师,zh-CN
+Druid,德鲁伊,zh-CN
+Fighter,战士,zh-CN
+Monk,武僧,zh-CN
+Paladin,圣武士,zh-CN
+Ranger,游侠,zh-CN
+Rogue,游荡者,zh-CN
+Sorcerer,术士,zh-CN
+Warlock,邪术师,zh-CN
+Wizard,法师,zh-CN
+Elf,精灵,zh-CN
+Tiefling,提夫林,zh-CN
+Drow,卓尔,zh-CN
+Human,人类,zh-CN
+Githyanki,吉斯洋基人,zh-CN
+Dwarf,矮人,zh-CN
+Half-Elf,半精灵,zh-CN
+Halfling,半身人,zh-CN
+Gnome,侏儒,zh-CN
+Dragonborn,龙裔,zh-CN
+Half-Orc,半兽人,zh-CN
+Athletics,运动,zh-CN
+Acrobatics,体操,zh-CN
+Sleight of Hand,巧手,zh-CN
+Stealth,隐匿,zh-CN
+Arcana,奥秘,zh-CN
+History,历史,zh-CN
+Investigation,调查,zh-CN
+Nature,自然,zh-CN
+Religion,宗教,zh-CN
+Animal Handling,驯兽,zh-CN
+Insight,洞察,zh-CN
+Medicine,医药,zh-CN
+Perception,察觉,zh-CN
+Survival,生存,zh-CN
+Deception,欺瞒,zh-CN
+Intimidation,威吓,zh-CN
+Performance,表演,zh-CN
+Persuasion,游说,zh-CN
+Spell Slot,法术位,zh-CN
+Saving Throw,豁免检定,zh-CN
+Ability Check,属性检定,zh-CN
+Difficulty Class,难度等级,zh-CN
+Attack Roll,攻击掷骰,zh-CN
+Armor Class,护甲等级,zh-CN
+Proficiency Bonus,熟练项加值,zh-CN
+Advantage,优势,zh-CN
+Disadvantage,劣势,zh-CN
+Long Rest,长休,zh-CN
+Short Rest,短休,zh-CN
+Hit Points,生命值,zh-CN
+Downed,倒地,zh-CN
+Opportunity Attack,借机攻击,zh-CN
+Reaction,反应,zh-CN
+Action,动作,zh-CN
+Bonus Action,附赠动作,zh-CN
+Cantrip,戏法,zh-CN
+Concentration,专注,zh-CN
+Charmed,魅惑,zh-CN
+Frightened,恐惧,zh-CN
+Poisoned,中毒,zh-CN
+Prone,仆倒,zh-CN
+Stunned,震慑,zh-CN
+Restrained,束缚,zh-CN
+Incapacitated,失能,zh-CN
+Paralyzed,麻痹,zh-CN
+Blindness,致盲,zh-CN
+The Dark Urge,邪念,zh-CN
+Mind Flayer,夺心魔,zh-CN
+Tadpole,幼体,zh-CN
+Absolute,至上真神,zh-CN
+True Soul,真魂者,zh-CN
+Camp,营地,zh-CN
+Guardian,守护者,zh-CN
+Artifact,遗物,zh-CN
+Acid Splash,酸液爆裂,zh-CN
+Blade Ward,剑刃防护,zh-CN
+Bone Chill,白骨之寒,zh-CN
+Dancing Lights,舞光术,zh-CN
+Eldritch Blast,魔能爆,zh-CN
+Fire Bolt,火焰箭,zh-CN
+Friends,交友术,zh-CN
+Guidance,神导术,zh-CN
+Light,光亮术,zh-CN
+Mage Hand,法师之手,zh-CN
+Minor Illusion,次级幻影,zh-CN
+Poison Spray,毒液喷射,zh-CN
+Produce Flame,产生火焰,zh-CN
+Ray of Frost,霜冻射线,zh-CN
+Resistance,抗性术,zh-CN
+Sacred Flame,圣火术,zh-CN
+Shillelagh,橡棍术,zh-CN
+Shocking Grasp,电爪,zh-CN
+Thaumaturgy,奇术,zh-CN
+Thorn Whip,荆棘之鞭,zh-CN
+True Strike,真打术,zh-CN
+Vicious Mockery,恶毒嘲笑,zh-CN
+Animal Friendship,动物交友术,zh-CN
+Armor of Agathys,阿加斯之铠,zh-CN
+Arms of Hadar,哈达之臂,zh-CN
+Bane,灾祸术,zh-CN
+Bless,祝福术,zh-CN
+Burning Hands,燃烧之手,zh-CN
+Charm Person,魅惑人类,zh-CN
+Chromatic Orb,炫彩球,zh-CN
+Color Spray,七彩喷射,zh-CN
+Command,命令术,zh-CN
+Compelled Duel,强制决斗,zh-CN
+Create Water,造水术,zh-CN
+Destroy Water,枯水术,zh-CN
+Cure Wounds,治疗伤口,zh-CN
+Disguise Self,自我伪装,zh-CN
+Dissonant Whispers,不和谐低语,zh-CN
+Divine Favor,神恩,zh-CN
+Ensnaring Strike,诱捕打击,zh-CN
+Entangle,纠缠术,zh-CN
+Expeditious Retreat,疾行术,zh-CN
+Faerie Fire,妖火术,zh-CN
+False Life,虚假生命,zh-CN
+Feather Fall,羽落术,zh-CN
+Find Familiar,寻找魔宠,zh-CN
+Fog Cloud,迷雾术,zh-CN
+Goodberry,神莓术,zh-CN
+Grease,油脂术,zh-CN
+Guiding Bolt,指引之箭,zh-CN
+Hail of Thorns,荆棘之雨,zh-CN
+Healing Word,治愈真言,zh-CN
+Hellish Rebuke,地狱惩击,zh-CN
+Heroism,英雄气概,zh-CN
+Ice Knife,冰刃术,zh-CN
+Inflict Wounds,致伤术,zh-CN
+Longstrider,大步奔行,zh-CN
+Mage Armor,法师护甲,zh-CN
+Magic Missile,魔法飞弹,zh-CN
+Protection from Evil and Good,防护善恶,zh-CN
+Ray of Sickness,致病射线,zh-CN
+Sanctuary,圣域术,zh-CN
+Searing Smite,炽烈惩击,zh-CN
+Shield,护盾术,zh-CN
+Shield of Faith,信仰之盾,zh-CN
+Sleep,睡眠术,zh-CN
+Speak with Animals,动物交谈,zh-CN
+Tasha's Hideous Laughter,塔莎狂笑术,zh-CN
+Thunderous Smite,雷鸣惩击,zh-CN
+Thunderwave,雷鸣波,zh-CN
+Witch Bolt,巫术箭,zh-CN
+Wrathful Smite,愤怒惩击,zh-CN
+Aid,援助术,zh-CN
+Barkskin,树皮术,zh-CN
+Blindness (spell),致盲术,zh-CN
+Blur,模糊术,zh-CN
+Cloud of Daggers,匕首云,zh-CN
+Crown of Madness,狂乱之冠,zh-CN
+Darkness,黑暗术,zh-CN
+Darkvision,黑暗视觉,zh-CN
+Detect Thoughts,侦测思想,zh-CN
+Enhance Ability,增强属性,zh-CN
+Enlarge/Reduce,变大/缩小,zh-CN
+Enthrall,迷魂术,zh-CN
+Flaming Sphere,烈焰球,zh-CN
+Gust of Wind,起风术,zh-CN
+Heat Metal,炽热金属,zh-CN
+Hold Person,定身人类,zh-CN
+Invisibility,隐形术,zh-CN
+Lesser Restoration,次级恢复术,zh-CN
+Magic Weapon,魔法武器,zh-CN
+Mirror Image,镜像术,zh-CN
+Misty Step,迷踪步,zh-CN
+Moonbeam,月光术,zh-CN
+Phantasmal Force,虚影之力,zh-CN
+Prayer of Healing,治愈祈祷,zh-CN
+Protection from Poison,毒素防护,zh-CN
+Ray of Enfeeblement,衰弱射线,zh-CN
+Scorching Ray,灼热射线,zh-CN
+Shatter,粉碎术,zh-CN
+Silence,沉默术,zh-CN
+Spiritual Weapon,灵体武器,zh-CN
+Web,蛛网术,zh-CN
+Animate Dead,操纵死尸,zh-CN
+Beacon of Hope,希望灯塔,zh-CN
+Bestow Curse,施放诅咒,zh-CN
+Call Lightning,召雷术,zh-CN
+Counterspell,法术反制,zh-CN
+Daylight,昼明术,zh-CN
+Fear,恐惧术,zh-CN
+Feign Death,假死术,zh-CN
+Fireball,火球术,zh-CN
+Fly,飞行术,zh-CN
+Gaseous Form,气态形体,zh-CN
+Glyph of Warding,守护之印,zh-CN
+Haste,加速术,zh-CN
+Hunger of Hadar,哈达之饥,zh-CN
+Hypnotic Pattern,催眠图纹,zh-CN
+Lightning Bolt,闪电束,zh-CN
+Mass Healing Word,群体治愈真言,zh-CN
+Plant Growth,植物滋长,zh-CN
+Protection from Energy,能量防护,zh-CN
+Revivify,回生术,zh-CN
+Sleet Storm,雨雪暴,zh-CN
+Slow,减速术,zh-CN
+Speak with Dead,死者交谈,zh-CN
+Spirit Guardians,灵体守卫,zh-CN
+Stinking Cloud,臭云术,zh-CN
+Vampiric Touch,吸血鬼之触,zh-CN
+Banishment,放逐术,zh-CN
+Blight,枯萎术,zh-CN
+Confusion,混乱术,zh-CN
+Conjure Minor Elementals,召唤次级元素,zh-CN
+Conjure Woodland Beings,召唤林地生物,zh-CN
+Death Ward,死亡防护,zh-CN
+Dimension Door,次元门,zh-CN
+Dominate Beast,支配野兽,zh-CN
+Evard's Black Tentacles,艾伐黑触手,zh-CN
+Fire Shield,火焰护盾,zh-CN
+Freedom of Movement,行动自由,zh-CN
+Greater Invisibility,高级隐形术,zh-CN
+Guardian of Faith,信仰守卫,zh-CN
+Ice Storm,冰风暴,zh-CN
+Otiluke's Resilient Sphere,欧提路克弹性球,zh-CN
+Phantasmal Killer,虚影杀手,zh-CN
+Polymorph,变形术,zh-CN
+Stoneskin,石肤术,zh-CN
+Wall of Fire,火墙术,zh-CN
+Cloudkill,死云术,zh-CN
+Cone of Cold,寒冰锥,zh-CN
+Conjure Elemental,召唤元素,zh-CN
+Contagion,传染术,zh-CN
+Destructive Wave,毁灭波,zh-CN
+Dominate Person,支配人类,zh-CN
+Flame Strike,烈焰击,zh-CN
+Greater Restoration,高级恢复术,zh-CN
+Hold Monster,定身怪物,zh-CN
+Insect Plague,虫群瘴气,zh-CN
+Mass Cure Wounds,群体治疗术,zh-CN
+Planar Binding,异界誓缚,zh-CN
+Seeming,似是而非,zh-CN
+Telekinesis,意念移物,zh-CN
+Wall of Stone,石墙术,zh-CN
+Arcane Gate,奥术之门,zh-CN
+Blade Barrier,剑刃障壁,zh-CN
+Chain Lightning,连环闪电,zh-CN
+Circle of Death,死亡之圈,zh-CN
+Create Undead,创造不死生物,zh-CN
+Disintegrate,解离术,zh-CN
+Eyebite,摄魂之眼,zh-CN
+Flesh to Stone,石化术,zh-CN
+Globe of Invulnerability,无敌球,zh-CN
+Harm,伤害术,zh-CN
+Heal,痊愈术,zh-CN
+Heroes' Feast,英雄宴,zh-CN
+Otiluke's Freezing Sphere,欧提路克冰冻球,zh-CN
+Otto's Irresistible Dance,奥图迷离舞,zh-CN
+Planar Ally,异界盟友,zh-CN
+Sunbeam,阳炎射线,zh-CN
+Wall of Ice,冰墙术,zh-CN
+Wall of Thorns,荆棘之墙,zh-CN
+Wind Walk,乘风而行,zh-CN
+The Nautiloid,螺壳舰,zh-CN
+Ravaged Beach,疮痍海滩,zh-CN
+Emerald Grove,翠绿林地,zh-CN
+Blighted Village,染疫村落,zh-CN
+Goblin Camp,地精营地,zh-CN
+Shattered Sanctum,破碎圣所,zh-CN
+Sunlit Wetlands,阳光湿地,zh-CN
+Putrid Bog,腐烂泥潭,zh-CN
+Riverside Teahouse,河边茶室,zh-CN
+Waukeen's Rest,沃金的休眠地,zh-CN
+The Risen Road,晋升之路,zh-CN
+Mountain Pass,山隘,zh-CN
+Rosymorn Monastery,瑰晨修道院,zh-CN
+Crèche Y'llek,伊雷珂养育间,zh-CN
+Underdark,幽暗地域,zh-CN
+Selûnite Outpost,塞伦涅哨所,zh-CN
+Myconid Colony,蕈人栖息地,zh-CN
+Dread Hollow,恐怖中空,zh-CN
+Arcane Tower,奥法高塔,zh-CN
+Grymforge,复仇之炉,zh-CN
+Adamantine Forge,精金熔炉,zh-CN
+Shadow-Cursed Lands,幽影诅咒之地,zh-CN
+Last Light Inn,终焉光芒旅店,zh-CN
+Reithwin Town,雷斯文小镇,zh-CN
+Moonrise Towers,月出之塔,zh-CN
+Grand Mausoleum,大陵寝,zh-CN
+Gauntlet of Shar,莎尔的试炼场,zh-CN
+Shadowfell,堕影冥界,zh-CN
+Rivington,利文顿,zh-CN
+Circus of the Last Days,末日马戏团,zh-CN
+Wyrm's Crossing,飞龙关,zh-CN
+Wyrm's Rock Fortress,飞龙岩要塞,zh-CN
+Lower City,下城区,zh-CN
+Elfsong Tavern,精灵之歌酒馆,zh-CN
+Sorcerous Sundries,巫术杂货铺,zh-CN
+The Counting House,计点屋,zh-CN
+House of Hope,希望之邸,zh-CN
+House of Grief,悲伤之邸,zh-CN
+Cazador's Palace,卡扎多尔的宫殿,zh-CN
+Bhaal Temple,巴尔神殿,zh-CN
+Upper City,上城区,zh-CN
+Shadowheart,影心,zh-CN
+Astarion,阿斯代伦,zh-CN
+Gale,盖尔,zh-CN
+Lae'zel,莱埃泽尔,zh-CN
+Wyll,威尔,zh-CN
+Karlach,卡菈克,zh-CN
+Halsin,哈尔辛,zh-CN
+Minthara,明萨拉,zh-CN
+Jaheira,贾希拉,zh-CN
+Minsc,明斯克,zh-CN
+Withers,守墓人,zh-CN
+The Emperor,君主,zh-CN
+Raphael,拉斐尔,zh-CN
+Mizora,米佐拉,zh-CN
+Dame Aylin,艾琳女士,zh-CN
+Isobel,伊索贝尔,zh-CN
+Volo,沃罗,zh-CN
+Scratch,挠挠,zh-CN
+Ketheric Thorm,凯瑟里克·索姆,zh-CN
+Enver Gortash,恩维尔·戈塔什,zh-CN
+Orin the Red,奥林,zh-CN

--- a/glossaries/bg3_zh-TW.csv
+++ b/glossaries/bg3_zh-TW.csv
@@ -1,0 +1,328 @@
+source,target,tgt_lng
+Strength,力量,zh-TW
+Dexterity,敏捷,zh-TW
+Constitution,體質,zh-TW
+Intelligence,智力,zh-TW
+Wisdom,感知,zh-TW
+Charisma,魅力,zh-TW
+Barbarian,野蠻人,zh-TW
+Bard,吟遊詩人,zh-TW
+Cleric,牧師,zh-TW
+Druid,德魯伊,zh-TW
+Fighter,戰士,zh-TW
+Monk,武僧,zh-TW
+Paladin,聖武士,zh-TW
+Ranger,遊俠,zh-TW
+Rogue,遊蕩者,zh-TW
+Sorcerer,術士,zh-TW
+Warlock,邪術師,zh-TW
+Wizard,法師,zh-TW
+Elf,精靈,zh-TW
+Tiefling,提夫林,zh-TW
+Drow,卓爾,zh-TW
+Human,人類,zh-TW
+Githyanki,吉斯洋基人,zh-TW
+Dwarf,矮人,zh-TW
+Half-Elf,半精靈,zh-TW
+Halfling,半身人,zh-TW
+Gnome,侏儒,zh-TW
+Dragonborn,龍裔,zh-TW
+Half-Orc,半獸人,zh-TW
+Athletics,運動,zh-TW
+Acrobatics,體操,zh-TW
+Sleight of Hand,巧手,zh-TW
+Stealth,隱匿,zh-TW
+Arcana,奧秘,zh-TW
+History,歷史,zh-TW
+Investigation,調查,zh-TW
+Nature,自然,zh-TW
+Religion,宗教,zh-TW
+Animal Handling,馴獸,zh-TW
+Insight,洞察,zh-TW
+Medicine,醫藥,zh-TW
+Perception,察覺,zh-TW
+Survival,生存,zh-TW
+Deception,欺瞞,zh-TW
+Intimidation,威嚇,zh-TW
+Performance,表演,zh-TW
+Persuasion,遊說,zh-TW
+Spell Slot,法術位,zh-TW
+Saving Throw,豁免檢定,zh-TW
+Ability Check,屬性檢定,zh-TW
+Difficulty Class,難度等級,zh-TW
+Attack Roll,攻擊擲骰,zh-TW
+Armor Class,護甲等級,zh-TW
+Proficiency Bonus,熟練項加值,zh-TW
+Advantage,優勢,zh-TW
+Disadvantage,劣勢,zh-TW
+Long Rest,長休,zh-TW
+Short Rest,短休,zh-TW
+Hit Points,生命值,zh-TW
+Downed,倒地,zh-TW
+Opportunity Attack,借機攻擊,zh-TW
+Reaction,反應,zh-TW
+Action,動作,zh-TW
+Bonus Action,附贈動作,zh-TW
+Cantrip,戲法,zh-TW
+Concentration,專注,zh-TW
+Charmed,魅惑,zh-TW
+Frightened,恐懼,zh-TW
+Poisoned,中毒,zh-TW
+Prone,仆倒,zh-TW
+Stunned,震懾,zh-TW
+Restrained,束縛,zh-TW
+Incapacitated,失能,zh-TW
+Paralyzed,麻痹,zh-TW
+Blindness,致盲,zh-TW
+The Dark Urge,邪念,zh-TW
+Mind Flayer,奪心魔,zh-TW
+Tadpole,幼體,zh-TW
+Absolute,至上真神,zh-TW
+True Soul,真魂者,zh-TW
+Camp,營地,zh-TW
+Guardian,守護者,zh-TW
+Artifact,遺物,zh-TW
+Acid Splash,酸液爆裂,zh-TW
+Blade Ward,劍刃防護,zh-TW
+Bone Chill,白骨之寒,zh-TW
+Dancing Lights,舞光術,zh-TW
+Eldritch Blast,魔能爆,zh-TW
+Fire Bolt,火焰箭,zh-TW
+Friends,交友術,zh-TW
+Guidance,神導術,zh-TW
+Light,光亮術,zh-TW
+Mage Hand,法師之手,zh-TW
+Minor Illusion,次級幻影,zh-TW
+Poison Spray,毒液噴射,zh-TW
+Produce Flame,產生火焰,zh-TW
+Ray of Frost,霜凍射線,zh-TW
+Resistance,抗性術,zh-TW
+Sacred Flame,聖火術,zh-TW
+Shillelagh,橡棍術,zh-TW
+Shocking Grasp,電爪,zh-TW
+Thaumaturgy,奇術,zh-TW
+Thorn Whip,荊棘之鞭,zh-TW
+True Strike,真打術,zh-TW
+Vicious Mockery,惡毒嘲笑,zh-TW
+Animal Friendship,動物交友術,zh-TW
+Armor of Agathys,阿加斯之鎧,zh-TW
+Arms of Hadar,哈達之臂,zh-TW
+Bane,災禍術,zh-TW
+Bless,祝福術,zh-TW
+Burning Hands,燃燒之手,zh-TW
+Charm Person,魅惑人類,zh-TW
+Chromatic Orb,炫彩球,zh-TW
+Color Spray,七彩噴射,zh-TW
+Command,命令術,zh-TW
+Compelled Duel,強制決鬥,zh-TW
+Create Water,造水術,zh-TW
+Destroy Water,枯水術,zh-TW
+Cure Wounds,治療傷口,zh-TW
+Disguise Self,自我偽裝,zh-TW
+Dissonant Whispers,不和諧低語,zh-TW
+Divine Favor,神恩,zh-TW
+Ensnaring Strike,誘捕打擊,zh-TW
+Entangle,糾纏術,zh-TW
+Expeditious Retreat,疾行術,zh-TW
+Faerie Fire,妖火術,zh-TW
+False Life,虛假生命,zh-TW
+Feather Fall,羽落術,zh-TW
+Find Familiar,尋找魔寵,zh-TW
+Fog Cloud,迷霧術,zh-TW
+Goodberry,神莓術,zh-TW
+Grease,油脂術,zh-TW
+Guiding Bolt,指引之箭,zh-TW
+Hail of Thorns,荊棘之雨,zh-TW
+Healing Word,治癒真言,zh-TW
+Hellish Rebuke,地獄懲擊,zh-TW
+Heroism,英雄氣概,zh-TW
+Ice Knife,冰刃術,zh-TW
+Inflict Wounds,致傷術,zh-TW
+Longstrider,大步奔行,zh-TW
+Mage Armor,法師護甲,zh-TW
+Magic Missile,魔法飛彈,zh-TW
+Protection from Evil and Good,防護善惡,zh-TW
+Ray of Sickness,致病射線,zh-TW
+Sanctuary,聖域術,zh-TW
+Searing Smite,熾烈懲擊,zh-TW
+Shield,護盾術,zh-TW
+Shield of Faith,信仰之盾,zh-TW
+Sleep,睡眠術,zh-TW
+Speak with Animals,動物交談,zh-TW
+Tasha's Hideous Laughter,塔莎狂笑術,zh-TW
+Thunderous Smite,雷鳴懲擊,zh-TW
+Thunderwave,雷鳴波,zh-TW
+Witch Bolt,巫術箭,zh-TW
+Wrathful Smite,憤怒懲擊,zh-TW
+Aid,援助術,zh-TW
+Barkskin,樹皮術,zh-TW
+Blindness (Spell),致盲術,zh-TW
+Blur,模糊術,zh-TW
+Cloud of Daggers,匕首雲,zh-TW
+Crown of Madness,狂亂之冠,zh-TW
+Darkness,黑暗術,zh-TW
+Darkvision,黑暗視覺,zh-TW
+Detect Thoughts,偵測思想,zh-TW
+Enhance Ability,增強屬性,zh-TW
+Enlarge/Reduce,變大/縮小,zh-TW
+Enthrall,迷魂術,zh-TW
+Flaming Sphere,烈焰球,zh-TW
+Gust of Wind,起風術,zh-TW
+Heat Metal,熾熱金屬,zh-TW
+Hold Person,定身人類,zh-TW
+Invisibility,隱形術,zh-TW
+Lesser Restoration,次級恢復術,zh-TW
+Magic Weapon,魔法武器,zh-TW
+Mirror Image,鏡像術,zh-TW
+Misty Step,迷蹤步,zh-TW
+Moonbeam,月光術,zh-TW
+Phantasmal Force,虛影之力,zh-TW
+Prayer of Healing,治癒祈禱,zh-TW
+Protection from Poison,毒素防護,zh-TW
+Ray of Enfeeblement,衰弱射線,zh-TW
+Scorching Ray,灼熱射線,zh-TW
+Shatter,粉碎術,zh-TW
+Silence,沉默術,zh-TW
+Spiritual Weapon,靈體武器,zh-TW
+Web,蛛網術,zh-TW
+Animate Dead,操縱死屍,zh-TW
+Beacon of Hope,希望燈塔,zh-TW
+Bestow Curse,施放詛咒,zh-TW
+Call Lightning,召雷術,zh-TW
+Counterspell,法術反制,zh-TW
+Daylight,晝明術,zh-TW
+Fear,恐懼術,zh-TW
+Feign Death,假死術,zh-TW
+Fireball,火球術,zh-TW
+Fly,飛行術,zh-TW
+Gaseous Form,氣態形體,zh-TW
+Glyph of Warding,守護之印,zh-TW
+Haste,加速術,zh-TW
+Hunger of Hadar,哈達之飢,zh-TW
+Hypnotic Pattern,催眠圖紋,zh-TW
+Lightning Bolt,閃電束,zh-TW
+Mass Healing Word,群體治癒真言,zh-TW
+Plant Growth,植物滋長,zh-TW
+Protection from Energy,能量防護,zh-TW
+Revivify,回生術,zh-TW
+Sleet Storm,雨雪暴,zh-TW
+Slow,減速術,zh-TW
+Speak with Dead,死者交談,zh-TW
+Spirit Guardians,靈體守衛,zh-TW
+Stinking Cloud,臭雲術,zh-TW
+Vampiric Touch,吸血鬼之觸,zh-TW
+Banishment,放逐術,zh-TW
+Blight,枯萎術,zh-TW
+Confusion,混亂術,zh-TW
+Conjure Minor Elementals,召喚次級元素,zh-TW
+Conjure Woodland Beings,召喚林地生物,zh-TW
+Death Ward,死亡防護,zh-TW
+Dimension Door,次元門,zh-TW
+Dominate Beast,支配野獸,zh-TW
+Evard's Black Tentacles,艾伐黑觸手,zh-TW
+Fire Shield,火焰護盾,zh-TW
+Freedom of Movement,行動自由,zh-TW
+Greater Invisibility,高級隱形術,zh-TW
+Guardian of Faith,信仰守衛,zh-TW
+Ice Storm,冰風暴,zh-TW
+Otiluke's Resilient Sphere,歐提路克彈性球,zh-TW
+Phantasmal Killer,虛影殺手,zh-TW
+Polymorph,變形術,zh-TW
+Stoneskin,石膚術,zh-TW
+Wall of Fire,火牆術,zh-TW
+Cloudkill,死雲術,zh-TW
+Cone of Cold,寒冰錐,zh-TW
+Conjure Elemental,召喚元素,zh-TW
+Contagion,傳染術,zh-TW
+Destructive Wave,毀滅波,zh-TW
+Dominate Person,支配人類,zh-TW
+Flame Strike,烈焰擊,zh-TW
+Greater Restoration,高級恢復術,zh-TW
+Hold Monster,定身怪物,zh-TW
+Insect Plague,蟲群瘴氣,zh-TW
+Mass Cure Wounds,群體治療術,zh-TW
+Planar Binding,異界誓縛,zh-TW
+Seeming,似是而非,zh-TW
+Telekinesis,意念移物,zh-TW
+Wall of Stone,石牆術,zh-TW
+Arcane Gate,奧術之門,zh-TW
+Blade Barrier,劍刃障壁,zh-TW
+Chain Lightning,連環閃電,zh-TW
+Circle of Death,死亡之圈,zh-TW
+Create Undead,創造不死生物,zh-TW
+Disintegrate,解離術,zh-TW
+Eyebite,攝魂之眼,zh-TW
+Flesh to Stone,石化術,zh-TW
+Globe of Invulnerability,無敵球,zh-TW
+Harm,傷害術,zh-TW
+Heal,痊癒術,zh-TW
+Heroes' Feast,英雄宴,zh-TW
+Otiluke's Freezing Sphere,歐提路克冷凍球,zh-TW
+Otto's Irresistible Dance,奧圖迷離舞,zh-TW
+Planar Ally,異界盟友,zh-TW
+Sunbeam,陽炎射線,zh-TW
+Wall of Ice,冰牆術,zh-TW
+Wall of Thorns,荊棘之牆,zh-TW
+Wind Walk,乘風而行,zh-TW
+The Nautiloid,螺殼艦,zh-TW
+Ravaged Beach,瘡痍海灘,zh-TW
+Emerald Grove,翠綠林地,zh-TW
+Blighted Village,染疫村落,zh-TW
+Goblin Camp,地精營地,zh-TW
+Shattered Sanctum,破碎聖所,zh-TW
+Sunlit Wetlands,陽光濕地,zh-TW
+Putrid Bog,腐爛泥潭,zh-TW
+Riverside Teahouse,河邊茶室,zh-TW
+Waukeen's Rest,沃金的休眠地,zh-TW
+The Risen Road,晉升之路,zh-TW
+Mountain Pass,山隘,zh-TW
+Rosymorn Monastery,瑰晨修道院,zh-TW
+Crèche Y'llek,伊雷珂養育間,zh-TW
+Underdark,幽暗地域,zh-TW
+Selûnite Outpost,塞倫涅哨所,zh-TW
+Myconid Colony,蕈人棲息地,zh-TW
+Dread Hollow,恐怖中空,zh-TW
+Arcane Tower,奧法高塔,zh-TW
+Grymforge,復仇之爐,zh-TW
+Adamantine Forge,精金熔爐,zh-TW
+Shadow-Cursed Lands,幽影詛咒之地,zh-TW
+Last Light Inn,終焉光芒旅店,zh-TW
+Reithwin Town,雷斯文小鎮,zh-TW
+Moonrise Towers,月出之塔,zh-TW
+Grand Mausoleum,大陵寢,zh-TW
+Gauntlet of Shar,莎爾的試煉場,zh-TW
+Shadowfell,墮影冥界,zh-TW
+Rivington,利文頓,zh-TW
+Circus of the Last Days,末日馬戲團,zh-TW
+Wyrm's Crossing,飛龍關,zh-TW
+Wyrm's Rock Fortress,飛龍岩要塞,zh-TW
+Lower City,下城區,zh-TW
+Elfsong Tavern,精靈之歌酒館,zh-TW
+Sorcerous Sundries,巫術雜貨鋪,zh-TW
+The Counting House,計點屋,zh-TW
+House of Hope,希望之邸,zh-TW
+House of Grief,悲傷之邸,zh-TW
+Cazador's Palace,卡扎多爾的宮殿,zh-TW
+Bhaal Temple,巴爾神殿,zh-TW
+Upper City,上城區,zh-TW
+Shadowheart,影心,zh-TW
+Astarion,阿斯代倫,zh-TW
+Gale,蓋爾,zh-TW
+Lae'zel,萊埃澤爾,zh-TW
+Wyll,威爾,zh-TW
+Karlach,卡菈克,zh-TW
+Halsin,哈爾辛,zh-TW
+Minthara,明薩拉,zh-TW
+Jaheira,賈希拉,zh-TW
+Minsc,明斯克,zh-TW
+Withers,守墓人,zh-TW
+The Emperor,君主,zh-TW
+Raphael,拉斐爾,zh-TW
+Mizora,米佐拉,zh-TW
+Dame Aylin,艾琳女士,zh-TW
+Isobel,伊索貝爾,zh-TW
+Volo,沃羅,zh-TW
+Scratch,撓撓,zh-TW
+Ketheric Thorm,凱瑟里克·索姆,zh-TW
+Enver Gortash,恩維爾·戈塔什,zh-TW
+Orin the Red,奧林,zh-TW

--- a/meta/bg3.json
+++ b/meta/bg3.json
@@ -1,0 +1,28 @@
+{
+  "id": "bg3",
+  "name": "Baldur's Gate 3",
+  "description": "Terminology for Baldur's Gate 3, including attributes, classes, races, spells, locations, and characters.",
+  "author": "Au3C2",
+  "glossary": "bg3",
+  "langs": [
+    "zh-CN",
+    "zh-TW"
+  ],
+  "i18ns": {
+    "zh-CN": {
+      "name": "博德之门 3",
+      "description": "博德之门 3 术语库，涵盖属性、职业、种族、法术、地点和角色名称。"
+    },
+    "zh-TW": {
+      "name": "博德之門 3",
+      "description": "博德之門 3 術語庫，涵蓋屬性、職業、種族、法術、地點和角色名稱。"
+    },
+    "en": {
+      "name": "Baldur's Gate 3",
+      "description": "Terminology for Baldur's Gate 3, including attributes, classes, races, spells, locations, and characters."
+    }
+  },
+  "matches": [
+    "https://bg3.wiki/*"
+  ]
+}

--- a/meta/index.json
+++ b/meta/index.json
@@ -27,5 +27,6 @@
     "stellar-blade-clothing",
     "Vocaloid",
     "access-control",
-    "hd2"
+    "hd2",
+    "bg3"
 ]


### PR DESCRIPTION
 摘要 (Summary)
  本项目新增了《博德之门 3》（Baldur's Gate 3）的中英文核心术语库，涵盖了游戏 Patch 7
  版本的最新官方译名与社区公认术语。该术语库旨在提升博德之门相关内容的翻译准确性，特别优化了沉浸翻译插件的匹配体验。

  变更内容 (Changes)
   - 新增术语文件：
     - glossaries/bg3_zh-CN.csv: 简体中文对照表，包含 330+ 条核心词汇。
     - glossaries/bg3_zh-TW.csv: 繁体中文对照表，针对港台语境进行了词汇对齐（如“遊蕩者”、“體質”等）。
   - 完善元数据：
     - meta/bg3.json: 定义了术语库的 ID、名称、多语言描述及作者信息。
     - meta/index.json: 将新术语库注册到全局索引中。

  术语范围 (Scope)
  本术语库严格遵循“仅术语”原则，排除了所有对话和长文本，精准聚焦于：
   - 基础属性与机制：力量、敏捷、护甲等级 (AC)、难度等级 (DC) 等。
   - 职业与种族：全 12 职业及 11 基础种族。
   - 法术列表：0 环至 6 环的核心法术名称。
   - 地理位置：涵盖第一章至第三章的主要地点名。
   - 核心角色：起源同伴、重要 NPC 及主要反派名称。

  备注 (Notes)
   - 数据版本：基于游戏 Patch 7 版本。
   - 整理日期：2026-05-10。
   - 格式规范：完全符合本项目现有的 CSV 和 JSON 规范。