### PR TITLE
feat: 新增生物学简体中文(zh-CN)权威术语库

### DIFF
--- a/glossaries/biology_zh-CN.csv
+++ b/glossaries/biology_zh-CN.csv
@@ -1,0 +1,27 @@
+source,target,tgt_lng
+taxonomic rank,分类层级,zh-CN
+superkingdom,总界,zh-CN
+subkingdom,亚界,zh-CN
+subphylum,亚门,zh-CN
+infraphylum,下门,zh-CN
+superclass,总纲,zh-CN
+subclass,亚纲,zh-CN
+infraclass,下纲,zh-CN
+superorder,总目,zh-CN
+suborder,亚目,zh-CN
+infraorder,下目,zh-CN
+superfamily,总科,zh-CN
+subfamily,亚科,zh-CN
+tribe,族,zh-CN
+subtribe,亚族,zh-CN
+subgenus,亚属,zh-CN
+subspecies,亚种,zh-CN
+type species,模式种,zh-CN
+type genus,模式属,zh-CN
+kingdom,界,zh-CN
+phylum,门,zh-CN
+class,纲,zh-CN
+order,目,zh-CN
+family,科,zh-CN
+genus,属,zh-CN
+species,种,zh-CN

--- a/meta/biology.json
+++ b/meta/biology.json
@@ -1,0 +1,27 @@
+{
+  "id": "biology",
+  "name": "Biology Expert",
+  "description": "Focuses on biological taxonomy ranks (Kingdom, Phylum, Class, Order, etc.) and core biological terms.",
+  "author": "mmlet",
+  "glossary": "biology",
+  "langs": [
+    "zh-CN"
+  ],
+  "matches": [
+    "*://*.wikipedia.org/*",
+    "*://*.wikidata.org/*",
+    "*://*.ncbi.nlm.nih.gov/*",
+    "*://*.nature.com/*",
+    "*://*.science.org/*",
+    "*://*.cell.com/*",
+    "*://*.gbif.org/*",
+    "*://*.biodiversitylibrary.org/*",
+    "*://*.iucnredlist.org/*"
+  ],
+  "i18ns": {
+    "zh-CN": {
+      "name": "生物学",
+      "description": "提供权威的生物分类学层级（界门纲目科属种）及常用生物学术语的英汉对照，纠正机器翻译的日常词汇混淆,且限制在特定网页,不误伤。"
+    }
+  }
+}

--- a/meta/index.json
+++ b/meta/index.json
@@ -28,5 +28,6 @@
     "Vocaloid",
     "access-control",
     "hd2",
-    "bg3"
+    "bg3",
+    "biology"
 ]


### PR DESCRIPTION
- 收录界门纲目科属种等核心分类层级词，修复机器翻译将其错译为日常词汇（如班级、命令）的问题。
- 引入 matches 字段限制生效域名，防止日常网页翻译遭到误伤。