### PR TITLE
feat: 增加电气工程术语

### DIFF
--- a/glossaries/electrical-engineering_zh-CN.csv
+++ b/glossaries/electrical-engineering_zh-CN.csv
@@ -1,0 +1,88 @@
+﻿source,target,tgt_lng
+Power Flow,潮流,zh-CN
+Power Angle,功角,zh-CN
+Power Swing,功率振荡,zh-CN
+Power Transmission,输电,zh-CN
+Bus,母线,zh-CN
+Feeder,馈线,zh-CN
+Branch,支路,zh-CN
+PQ Bus,PQ节点,zh-CN
+Load,负荷,zh-CN
+Load Shedding,切负荷,zh-CN
+Generator,发电机,zh-CN
+Governor,调速器,zh-CN
+Exciter,励磁机,zh-CN
+Rotor Angle Stability,功角稳定,zh-CN
+Cascading Failure,连锁故障,zh-CN
+Contingency Analysis,预想事故分析,zh-CN
+Energy Management System,能量管理系统,zh-CN
+Phasor Measurement Unit,相量测量单元,zh-CN
+Protective Relay,继电保护装置,zh-CN
+Voltage Sag,电压暂降,zh-CN
+Voltage Swell,电压暂升,zh-CN
+Clearance,电气间隙,zh-CN
+Winding,绕组,zh-CN
+Armature,电枢,zh-CN
+Brush,电刷,zh-CN
+Locked Rotor,堵转,zh-CN
+Pull-Out Torque,最大转矩,zh-CN
+Fuse,熔断器,zh-CN
+Relay,继电器,zh-CN
+Conductor,导体,zh-CN
+Insulator,绝缘子,zh-CN
+Transmission Line,输电线路,zh-CN
+Current,电流,zh-CN
+Resistance,电阻,zh-CN
+Phase,相位,zh-CN
+Line Voltage,线电压,zh-CN
+Form Factor,波形因数,zh-CN
+Kirchhoff's Current Law,基尔霍夫电流定律,zh-CN
+Flux Density,磁通密度,zh-CN
+Reluctance,磁阻,zh-CN
+Permeability,磁导率,zh-CN
+Hysteresis,磁滞,zh-CN
+Converter,变流器,zh-CN
+Chopper,斩波器,zh-CN
+Cycloconverter,周波变流器,zh-CN
+Gate Turn-Off Thyristor,门极可关断晶闸管,zh-CN
+Zener Diode,齐纳二极管,zh-CN
+Filter,滤波器,zh-CN
+Gain Margin,增益裕度,zh-CN
+Settling Time,调节时间,zh-CN
+Overshoot,超调量,zh-CN
+Luenberger Observer,龙伯格观测器,zh-CN
+Disturbance,扰动,zh-CN
+Noise,噪声,zh-CN
+White Noise,白噪声,zh-CN
+Impulse Response,冲激响应,zh-CN
+Primal Problem,原问题,zh-CN
+Branch and Bound,分支定界,zh-CN
+Barrier Method,障碍函数法,zh-CN
+Spline Interpolation,样条插值,zh-CN
+Truncation Error,截断误差,zh-CN
+Ill-Conditioned,病态,zh-CN
+Well-Conditioned,良态,zh-CN
+Graph,图,zh-CN
+Edge,边,zh-CN
+Degree,度,zh-CN
+Out-Degree,出度,zh-CN
+Cycle,回路,zh-CN
+Clique,团,zh-CN
+Cut Set,割集,zh-CN
+Flow Network,流网络,zh-CN
+Softmax,Softmax函数,zh-CN
+Stride,步长,zh-CN
+Exploding Gradient,梯度爆炸,zh-CN
+Dropout,Dropout,zh-CN
+Adam,Adam优化器,zh-CN
+Epoch,轮次,zh-CN
+Batch Size,批次大小,zh-CN
+Overfitting,过拟合,zh-CN
+Attention Mechanism,注意力机制,zh-CN
+Self-Attention,自注意力,zh-CN
+Trace Class Operator,迹类算子,zh-CN
+Resolvent,预解式,zh-CN
+Spectrum,谱,zh-CN
+Continuous Spectrum,连续谱,zh-CN
+Norm,范数,zh-CN
+Functional Calculus,函数演算,zh-CN

--- a/glossaries/electrical-engineering_zh-TW.csv
+++ b/glossaries/electrical-engineering_zh-TW.csv
@@ -1,0 +1,88 @@
+﻿source,target,tgt_lng
+Power Flow,潮流,zh-TW
+Power Angle,功角,zh-TW
+Power Swing,功率振盪,zh-TW
+Power Transmission,輸電,zh-TW
+Bus,母線,zh-TW
+Feeder,饋線,zh-TW
+Branch,支路,zh-TW
+PQ Bus,PQ節點,zh-TW
+Load,負荷,zh-TW
+Load Shedding,切負荷,zh-TW
+Generator,發電機,zh-TW
+Governor,調速器,zh-TW
+Exciter,勵磁機,zh-TW
+Rotor Angle Stability,功角穩定,zh-TW
+Cascading Failure,連鎖故障,zh-TW
+Contingency Analysis,預想事故分析,zh-TW
+Energy Management System,能量管理系統,zh-TW
+Phasor Measurement Unit,相量測量單元,zh-TW
+Protective Relay,繼電保護裝置,zh-TW
+Voltage Sag,電壓暫降,zh-TW
+Voltage Swell,電壓暫升,zh-TW
+Clearance,電氣間隙,zh-TW
+Winding,繞組,zh-TW
+Armature,電樞,zh-TW
+Brush,電刷,zh-TW
+Locked Rotor,堵轉,zh-TW
+Pull-Out Torque,最大轉矩,zh-TW
+Fuse,鎔斷器,zh-TW
+Relay,繼電器,zh-TW
+Conductor,導體,zh-TW
+Insulator,絕緣子,zh-TW
+Transmission Line,輸電線路,zh-TW
+Current,電流,zh-TW
+Resistance,電阻,zh-TW
+Phase,相位,zh-TW
+Line Voltage,線電壓,zh-TW
+Form Factor,波形因數,zh-TW
+Kirchhoff's Current Law,基爾霍夫電流定律,zh-TW
+Flux Density,磁通密度,zh-TW
+Reluctance,磁阻,zh-TW
+Permeability,磁導率,zh-TW
+Hysteresis,磁滯,zh-TW
+Converter,變流器,zh-TW
+Chopper,斬波器,zh-TW
+Cycloconverter,週波變流器,zh-TW
+Gate Turn-Off Thyristor,門極可關斷晶閘管,zh-TW
+Zener Diode,齊納二極管,zh-TW
+Filter,濾波器,zh-TW
+Gain Margin,增益裕度,zh-TW
+Settling Time,調節時間,zh-TW
+Overshoot,超調量,zh-TW
+Luenberger Observer,龍伯格觀測器,zh-TW
+Disturbance,擾動,zh-TW
+Noise,噪聲,zh-TW
+White Noise,白噪聲,zh-TW
+Impulse Response,衝激響應,zh-TW
+Primal Problem,原問題,zh-TW
+Branch and Bound,分支定界,zh-TW
+Barrier Method,障礙函數法,zh-TW
+Spline Interpolation,樣條插值,zh-TW
+Truncation Error,截斷誤差,zh-TW
+Ill-Conditioned,病態,zh-TW
+Well-Conditioned,良態,zh-TW
+Graph,圖,zh-TW
+Edge,邊,zh-TW
+Degree,度,zh-TW
+Out-Degree,出度,zh-TW
+Cycle,回路,zh-TW
+Clique,團,zh-TW
+Cut Set,割集,zh-TW
+Flow Network,流網絡,zh-TW
+Softmax,Softmax函數,zh-TW
+Stride,步長,zh-TW
+Exploding Gradient,梯度爆炸,zh-TW
+Dropout,Dropout,zh-TW
+Adam,Adam優化器,zh-TW
+Epoch,輪次,zh-TW
+Batch Size,批次大小,zh-TW
+Overfitting,過擬合,zh-TW
+Attention Mechanism,注意力機制,zh-TW
+Self-Attention,自注意力,zh-TW
+Trace Class Operator,跡類算子,zh-TW
+Resolvent,預解式,zh-TW
+Spectrum,譜,zh-TW
+Continuous Spectrum,連續譜,zh-TW
+Norm,範數,zh-TW
+Functional Calculus,函數演算,zh-TW

--- a/meta/electrical-engineering.json
+++ b/meta/electrical-engineering.json
@@ -1,0 +1,25 @@
+{
+  "id": "electrical-engineering",
+  "name": "Electrical Engineering",
+  "description": "Glossary for electrical engineering, covering power systems, heavy current engineering, system theory, optimization theory, numerical methods, graph theory, artificial neural networks, and operator theory.",
+  "author": "immersive",
+  "glossary": "electrical-engineering",
+  "langs": [
+    "zh-CN",
+    "zh-TW"
+  ],
+  "i18ns": {
+    "zh-CN": {
+      "name": "电气工程",
+      "description": "电气工程术语库，涵盖电力系统及其自动化、强电、系统理论、优化理论、数值计算方法、图论、人工神经网络和算子理论等方向的专业术语翻译。"
+    },
+    "zh-TW": {
+      "name": "電氣工程",
+      "description": "電氣工程術語庫，涵蓋電力系統及其自動化、強電、系統理論、最佳化理論、數值計算方法、圖論、人工神經網路和算子理論等方向的專業術語翻譯。"
+    },
+    "en": {
+      "name": "Electrical Engineering",
+      "description": "Glossary for electrical engineering, covering power systems, heavy current engineering, system theory, optimization theory, numerical methods, graph theory, artificial neural networks, and operator theory."
+    }
+  }
+}

--- a/meta/index.json
+++ b/meta/index.json
@@ -28,5 +28,6 @@
     "Vocaloid",
     "access-control",
     "hd2",
-    "bg3"
+    "bg3",
+    "electrical-engineering"
 ]


### PR DESCRIPTION
- 共新增87条电气工程领域术语
- 覆盖9个子领域：电力系统及其自动化、强电、电气工程通用、系统理论、优化理论、数值计算方法、图论、人工神经网络、算子理论
- 使用机器翻译从568条领域术语中验证了无法正确翻译的87条，确保术语表的必要性