### PR TITLE
feat: add general language glossaries

### DIFF
--- a/glossaries/common-everyday_zh-CN.csv
+++ b/glossaries/common-everyday_zh-CN.csv
@@ -1,0 +1,797 @@
+source,target,tgt_lng
+account settings,账户设置,zh-CN
+account overview,账户概览,zh-CN
+account information,账户信息,zh-CN
+account details,账户详细信息,zh-CN
+account holder,账户持有人,zh-CN
+account number,账户号码,zh-CN
+account balance,账户余额,zh-CN
+account status,账户状态,zh-CN
+account activity,账户活动记录,zh-CN
+account history,账户历史记录,zh-CN
+account recovery,账户恢复,zh-CN
+account verification,账户验证,zh-CN
+verify your account,验证您的账户,zh-CN
+create an account,创建账户,zh-CN
+open an account,开立账户,zh-CN
+close an account,关闭账户,zh-CN
+delete your account,删除您的账户,zh-CN
+deactivate your account,停用您的账户,zh-CN
+reactivate your account,重新启用您的账户,zh-CN
+switch accounts,切换账户,zh-CN
+add another account,添加其他账户,zh-CN
+personal account,个人账户,zh-CN
+business account,企业账户,zh-CN
+joint account,联名账户,zh-CN
+guest account,访客账户,zh-CN
+account administrator,账户管理员,zh-CN
+profile settings,个人资料设置,zh-CN
+profile information,个人资料信息,zh-CN
+profile picture,个人资料图片,zh-CN
+preferred name,常用姓名,zh-CN
+name on account,账户登记姓名,zh-CN
+date of birth,出生日期,zh-CN
+preferred language,首选语言,zh-CN
+communication preferences,沟通偏好,zh-CN
+notification preferences,通知偏好,zh-CN
+email notifications,电子邮件通知,zh-CN
+text message notifications,短信通知,zh-CN
+push notifications,推送通知,zh-CN
+marketing communications,营销信息,zh-CN
+unsubscribe from emails,取消订阅电子邮件,zh-CN
+manage subscriptions,管理订阅,zh-CN
+sign-in information,登录信息,zh-CN
+sign-in method,登录方式,zh-CN
+sign-in attempt,登录尝试,zh-CN
+sign-in activity,登录活动记录,zh-CN
+sign in with email,使用电子邮件登录,zh-CN
+sign in with phone number,使用手机号码登录,zh-CN
+sign in with Apple,通过 Apple 登录,zh-CN
+sign in with Google,通过 Google 登录,zh-CN
+sign in with Microsoft,通过 Microsoft 登录,zh-CN
+continue as guest,以访客身份继续,zh-CN
+stay signed in,保持登录状态,zh-CN
+sign out of all devices,从所有设备退出登录,zh-CN
+session expired,会话已过期,zh-CN
+active session,当前活动会话,zh-CN
+trusted device,受信任设备,zh-CN
+recognized device,已识别设备,zh-CN
+new device detected,检测到新设备,zh-CN
+unrecognized sign-in,无法识别的登录,zh-CN
+suspicious activity detected,检测到可疑活动,zh-CN
+security alert,安全提醒,zh-CN
+security settings,安全设置,zh-CN
+security checkup,安全检查,zh-CN
+login credentials,登录凭据,zh-CN
+username or email,用户名或电子邮件,zh-CN
+current password,当前密码,zh-CN
+confirm new password,确认新密码,zh-CN
+forgot your password,忘记密码,zh-CN
+reset your password,重置密码,zh-CN
+password reset link,密码重置链接,zh-CN
+password reset email,密码重置邮件,zh-CN
+password requirements,密码要求,zh-CN
+password strength,密码强度,zh-CN
+one-time passcode,一次性验证码,zh-CN
+verification code,验证码,zh-CN
+recovery code,恢复代码,zh-CN
+recovery email address,恢复用电子邮件地址,zh-CN
+recovery phone number,恢复用手机号码,zh-CN
+security question,安全问题,zh-CN
+biometric authentication,生物识别身份验证,zh-CN
+identity verification,身份验证,zh-CN
+proof of identity,身份证明,zh-CN
+government-issued ID,政府签发的身份证件,zh-CN
+proof of address,地址证明,zh-CN
+upload your ID,上传身份证件,zh-CN
+verify your identity,验证您的身份,zh-CN
+privacy settings,隐私设置,zh-CN
+privacy preferences,隐私偏好,zh-CN
+privacy notice,隐私声明,zh-CN
+privacy choices,隐私选项,zh-CN
+privacy rights,隐私权利,zh-CN
+personal information,个人信息,zh-CN
+sensitive personal information,敏感个人信息,zh-CN
+personal data request,个人数据请求,zh-CN
+access your data,访问您的数据,zh-CN
+download your data,下载您的数据,zh-CN
+delete your data,删除您的数据,zh-CN
+correct your information,更正您的信息,zh-CN
+data retention period,数据保留期限,zh-CN
+data processing purposes,数据处理目的,zh-CN
+data sharing partners,数据共享合作方,zh-CN
+third-party services,第三方服务,zh-CN
+third-party cookies,第三方 Cookie,zh-CN
+essential cookies,必要 Cookie,zh-CN
+optional cookies,可选 Cookie,zh-CN
+cookie preferences,Cookie 偏好设置,zh-CN
+cookie consent,Cookie 使用同意,zh-CN
+accept all cookies,接受所有 Cookie,zh-CN
+reject non-essential cookies,拒绝非必要 Cookie,zh-CN
+manage cookie settings,管理 Cookie 设置,zh-CN
+do not sell my personal information,请勿出售我的个人信息,zh-CN
+do not share my personal information,请勿共享我的个人信息,zh-CN
+opt out of targeted advertising,退出定向广告,zh-CN
+interest-based advertising,基于兴趣的广告,zh-CN
+location permissions,位置权限,zh-CN
+camera permissions,相机权限,zh-CN
+microphone permissions,麦克风权限,zh-CN
+contacts permissions,通讯录权限,zh-CN
+photo library access,照片图库访问权限,zh-CN
+allow while using the app,仅在使用 App 时允许,zh-CN
+ask every time,每次询问,zh-CN
+permission denied,权限被拒绝,zh-CN
+manage app permissions,管理 App 权限,zh-CN
+accessibility settings,辅助功能设置,zh-CN
+display settings,显示设置,zh-CN
+language settings,语言设置,zh-CN
+region settings,地区设置,zh-CN
+time zone settings,时区设置,zh-CN
+high contrast mode,高对比度模式,zh-CN
+screen reader support,屏幕阅读器支持,zh-CN
+keyboard navigation,键盘导航,zh-CN
+closed caption settings,隐藏式字幕设置,zh-CN
+support center,支持中心,zh-CN
+contact support,联系支持团队,zh-CN
+customer support representative,客户支持专员,zh-CN
+submit a request,提交请求,zh-CN
+support ticket,支持工单,zh-CN
+support ticket number,工单编号,zh-CN
+report a problem,报告问题,zh-CN
+report inappropriate content,举报不当内容,zh-CN
+send feedback,发送反馈,zh-CN
+feedback form,反馈表,zh-CN
+frequently asked questions (FAQ),常见问题 FAQ,zh-CN
+step-by-step instructions,分步说明,zh-CN
+troubleshooting guide,故障排除指南,zh-CN
+service status page,服务状态页面,zh-CN
+scheduled maintenance,计划维护,zh-CN
+temporary service interruption,服务暂时中断,zh-CN
+page not found,找不到页面,zh-CN
+access denied,访问被拒绝,zh-CN
+request timed out,请求超时,zh-CN
+something went wrong,出现问题,zh-CN
+try again later,请稍后重试,zh-CN
+refresh the page,刷新页面,zh-CN
+return to homepage,返回首页,zh-CN
+open in new window,在新窗口中打开,zh-CN
+open in new tab,在新标签页中打开,zh-CN
+copy link address,复制链接地址,zh-CN
+share this page,分享此页面,zh-CN
+print this page,打印此页面,zh-CN
+download as PDF,下载为 PDF,zh-CN
+save for later,稍后保存,zh-CN
+add to favorites,添加到收藏夹,zh-CN
+remove from favorites,从收藏夹移除,zh-CN
+recently viewed,最近浏览,zh-CN
+recommended for you,为您推荐,zh-CN
+related articles,相关文章,zh-CN
+search results,搜索结果,zh-CN
+no results found,未找到结果,zh-CN
+clear search history,清除搜索历史记录,zh-CN
+advanced search,高级搜索,zh-CN
+search filters,搜索筛选条件,zh-CN
+sort by relevance,按相关性排序,zh-CN
+sort by newest,按最新排序,zh-CN
+show more results,显示更多结果,zh-CN
+load more items,加载更多项目,zh-CN
+expand all sections,展开所有部分,zh-CN
+collapse all sections,折叠所有部分,zh-CN
+required field,必填字段,zh-CN
+optional field,选填字段,zh-CN
+invalid entry,输入无效,zh-CN
+please select an option,请选择一个选项,zh-CN
+changes saved,更改已保存,zh-CN
+unsaved changes,未保存的更改,zh-CN
+discard changes,放弃更改,zh-CN
+save your changes,保存更改,zh-CN
+confirm your selection,确认您的选择,zh-CN
+cancel and return,取消并返回,zh-CN
+terms and conditions,条款与条件,zh-CN
+acceptable use policy,可接受使用政策,zh-CN
+community guidelines,社区准则,zh-CN
+copyright notice,版权声明,zh-CN
+all rights reserved,保留所有权利,zh-CN
+effective date,生效日期,zh-CN
+shopping cart,购物车,zh-CN
+add to cart,加入购物车,zh-CN
+add to bag,加入购物袋,zh-CN
+buy it now,立即购买,zh-CN
+continue shopping,继续购物,zh-CN
+proceed to checkout,前往结账,zh-CN
+express checkout,快捷结账,zh-CN
+guest checkout,访客结账,zh-CN
+secure checkout,安全结账,zh-CN
+checkout page,结账页面,zh-CN
+order summary,订单摘要,zh-CN
+order subtotal,订单小计,zh-CN
+estimated total,预计总额,zh-CN
+regular price,原价,zh-CN
+price before tax,税前价格,zh-CN
+price includes tax,价格含税,zh-CN
+estimated tax,预计税费,zh-CN
+value-added tax (VAT),增值税 VAT,zh-CN
+goods and services tax (GST),商品及服务税 GST,zh-CN
+processing fee,处理费,zh-CN
+convenience fee,便利费,zh-CN
+customs duties,关税,zh-CN
+import charges,进口费用,zh-CN
+additional charges may apply,可能会产生额外费用,zh-CN
+discount code,折扣码,zh-CN
+apply discount,使用折扣,zh-CN
+discount applied,已使用折扣,zh-CN
+gift card balance,礼品卡余额,zh-CN
+loyalty points,会员积分,zh-CN
+rewards balance,奖励余额,zh-CN
+limited-time offer,限时优惠,zh-CN
+while supplies last,售完即止,zh-CN
+online exclusive,线上专享,zh-CN
+price match guarantee,价格匹配保证,zh-CN
+lowest price guarantee,最低价保证,zh-CN
+out of stock,缺货,zh-CN
+back in stock,恢复有货,zh-CN
+only a few left,仅剩少量,zh-CN
+available for preorder,可预订,zh-CN
+preorder release date,预订商品发售日期,zh-CN
+expected availability,预计有货时间,zh-CN
+product availability,商品供应情况,zh-CN
+select a size,选择尺码,zh-CN
+select a color,选择颜色,zh-CN
+product dimensions,商品尺寸,zh-CN
+product specifications,商品规格,zh-CN
+product description,商品说明,zh-CN
+product details,商品详情,zh-CN
+product features,商品特点,zh-CN
+materials and care,材质与保养,zh-CN
+care instructions,保养说明,zh-CN
+country of origin,原产国,zh-CN
+manufacturer warranty,制造商保修,zh-CN
+limited warranty,有限保修,zh-CN
+warranty period,保修期,zh-CN
+warranty claim,保修申请,zh-CN
+proof of purchase,购买凭证,zh-CN
+customer reviews,顾客评价,zh-CN
+verified purchase,已验证购买,zh-CN
+write a review,撰写评价,zh-CN
+helpful review,有帮助的评价,zh-CN
+seller information,卖家信息,zh-CN
+sold and shipped by,销售及配送方,zh-CN
+authorized retailer,授权零售商,zh-CN
+third-party seller,第三方卖家,zh-CN
+marketplace seller,平台卖家,zh-CN
+seller rating,卖家评分,zh-CN
+contact the seller,联系卖家,zh-CN
+payment method,付款方式,zh-CN
+preferred payment method,首选付款方式,zh-CN
+add a payment method,添加付款方式,zh-CN
+remove payment method,移除付款方式,zh-CN
+credit card number,信用卡号,zh-CN
+debit card number,借记卡号,zh-CN
+cardholder name,持卡人姓名,zh-CN
+card expiration date,银行卡有效期,zh-CN
+card security code,银行卡安全码,zh-CN
+billing address,账单地址,zh-CN
+shipping address,收货地址,zh-CN
+same as billing address,与账单地址相同,zh-CN
+digital wallet,数字钱包,zh-CN
+bank transfer,银行转账,zh-CN
+electronic funds transfer,电子资金转账,zh-CN
+cash on delivery,货到付款,zh-CN
+buy now pay later,先买后付,zh-CN
+installment plan,分期付款计划,zh-CN
+monthly installment,每月分期付款,zh-CN
+automatic payment,自动付款,zh-CN
+recurring payment,定期付款,zh-CN
+payment authorization,付款授权,zh-CN
+payment confirmation,付款确认,zh-CN
+payment pending,付款处理中,zh-CN
+payment declined,付款被拒绝,zh-CN
+payment failed,付款失败,zh-CN
+payment received,已收到付款,zh-CN
+payment refunded,付款已退回,zh-CN
+duplicate charge,重复扣款,zh-CN
+unauthorized charge,未经授权的扣款,zh-CN
+pending charge,待处理扣款,zh-CN
+transaction history,交易记录,zh-CN
+transaction number,交易编号,zh-CN
+receipt number,收据编号,zh-CN
+electronic receipt,电子收据,zh-CN
+request a receipt,索取收据,zh-CN
+download receipt,下载收据,zh-CN
+invoice address,发票地址,zh-CN
+itemized invoice,明细发票,zh-CN
+purchase date,购买日期,zh-CN
+order confirmed,订单已确认,zh-CN
+order processing,订单处理中,zh-CN
+order canceled,订单已取消,zh-CN
+cancel your order,取消您的订单,zh-CN
+modify your order,修改您的订单,zh-CN
+track your order,跟踪您的订单,zh-CN
+order tracking number,订单跟踪号,zh-CN
+estimated delivery date,预计送达日期,zh-CN
+scheduled delivery date,计划送达日期,zh-CN
+delivery window,送达时间段,zh-CN
+standard shipping,标准配送,zh-CN
+expedited shipping,加急配送,zh-CN
+same-day delivery,当日送达,zh-CN
+next-day delivery,次日送达,zh-CN
+free shipping,免运费,zh-CN
+in-store pickup,到店自取,zh-CN
+curbside pickup,路边取货,zh-CN
+pickup location,取货地点,zh-CN
+pickup instructions,取货说明,zh-CN
+ready for pickup,可以取货,zh-CN
+package shipped,包裹已发出,zh-CN
+package in transit,包裹运输中,zh-CN
+package delayed,包裹延误,zh-CN
+package delivered,包裹已送达,zh-CN
+delivery attempted,已尝试投递,zh-CN
+delivery exception,配送异常,zh-CN
+signature required,需要签收,zh-CN
+leave at the door,放在门口,zh-CN
+delivery instructions,配送说明,zh-CN
+shipping carrier,承运商,zh-CN
+local courier,本地快递公司,zh-CN
+last-mile delivery,末端配送,zh-CN
+package tracking,包裹追踪,zh-CN
+tracking information,追踪信息,zh-CN
+return policy,退货政策,zh-CN
+return window,退货期限,zh-CN
+return eligibility,退货资格,zh-CN
+start a return,发起退货,zh-CN
+return authorization,退货授权,zh-CN
+return merchandise authorization (RMA),退货授权 RMA,zh-CN
+return shipping label,退货运单标签,zh-CN
+prepaid return label,预付费退货标签,zh-CN
+return shipping fee,退货运费,zh-CN
+return to store,到店退货,zh-CN
+exchange an item,换货,zh-CN
+replacement item,替换商品,zh-CN
+refund method,退款方式,zh-CN
+refund status,退款状态,zh-CN
+refund processing time,退款处理时间,zh-CN
+partial refund,部分退款,zh-CN
+original payment method,原付款方式,zh-CN
+store credit refund,以商店余额退款,zh-CN
+defective item,商品有缺陷,zh-CN
+wrong item received,收到错误商品,zh-CN
+package not received,未收到包裹,zh-CN
+report a delivery issue,报告配送问题,zh-CN
+travel itinerary,旅行行程,zh-CN
+trip itinerary,出行行程,zh-CN
+departure date,出发日期,zh-CN
+travel destination,旅行目的地,zh-CN
+point of departure,出发地点,zh-CN
+multi-city trip,多城市行程,zh-CN
+direct flight,直飞航班,zh-CN
+connecting flight,转机航班,zh-CN
+nonstop flight,不经停航班,zh-CN
+flight number,航班号,zh-CN
+flight schedule,航班时刻表,zh-CN
+flight status,航班状态,zh-CN
+flight duration,飞行时长,zh-CN
+departure time,出发时间,zh-CN
+estimated departure time,预计起飞时间,zh-CN
+estimated arrival time,预计到达时间,zh-CN
+scheduled departure time,计划起飞时间,zh-CN
+scheduled arrival time,计划到达时间,zh-CN
+departure airport,出发机场,zh-CN
+arrival airport,到达机场,zh-CN
+origin airport,始发机场,zh-CN
+destination airport,目的地机场,zh-CN
+departure terminal,出发航站楼,zh-CN
+arrival terminal,到达航站楼,zh-CN
+terminal transfer,航站楼间转乘,zh-CN
+airport transfer,机场接送,zh-CN
+airport shuttle,机场班车,zh-CN
+airport lounge,机场休息室,zh-CN
+lounge access,休息室使用资格,zh-CN
+airport security checkpoint,机场安检口,zh-CN
+security screening,安全检查,zh-CN
+passport control,护照查验,zh-CN
+border control,边境检查,zh-CN
+customs declaration,海关申报,zh-CN
+customs inspection,海关检查,zh-CN
+immigration officer,移民检查官,zh-CN
+entry requirements,入境要求,zh-CN
+exit requirements,出境要求,zh-CN
+visa requirements,签证要求,zh-CN
+visa application,签证申请,zh-CN
+visa appointment,签证预约,zh-CN
+visa processing time,签证处理时间,zh-CN
+visa-free entry,免签入境,zh-CN
+visa on arrival,落地签证,zh-CN
+electronic travel authorization,电子旅行授权,zh-CN
+travel document,旅行证件,zh-CN
+passport number,护照号码,zh-CN
+passport expiration date,护照有效期,zh-CN
+passport validity,护照有效期限,zh-CN
+country of citizenship,国籍所属国,zh-CN
+country of residence,居住国,zh-CN
+place of birth,出生地,zh-CN
+emergency contact,紧急联系人,zh-CN
+trip cancellation insurance,行程取消保险,zh-CN
+travel medical insurance,旅行医疗保险,zh-CN
+insurance policy number,保险单号,zh-CN
+insurance coverage,保险保障范围,zh-CN
+file an insurance claim,提出保险理赔申请,zh-CN
+airline reservation,航空公司预订,zh-CN
+reservation number,预订编号,zh-CN
+booking reference,预订参考编号,zh-CN
+confirmation number,确认编号,zh-CN
+electronic ticket,电子客票,zh-CN
+airline ticket number,机票票号,zh-CN
+passenger name,乘客姓名,zh-CN
+passenger details,乘客信息,zh-CN
+frequent flyer number,常旅客会员号,zh-CN
+frequent flyer program,常旅客计划,zh-CN
+loyalty program number,会员计划编号,zh-CN
+seat selection,选座,zh-CN
+seat assignment,座位分配,zh-CN
+extra-legroom seat,加大腿部空间座位,zh-CN
+accessible seating,无障碍座位,zh-CN
+traveling with an infant,携带婴儿出行,zh-CN
+unaccompanied minor,无成人陪伴儿童,zh-CN
+special assistance,特殊协助,zh-CN
+wheelchair assistance,轮椅协助,zh-CN
+mobility assistance,行动协助,zh-CN
+dietary requirements,饮食要求,zh-CN
+special meal request,特殊餐食申请,zh-CN
+check-in online,网上办理值机,zh-CN
+airport check-in,机场办理值机,zh-CN
+check-in deadline,值机截止时间,zh-CN
+boarding pass,登机牌,zh-CN
+mobile boarding pass,手机登机牌,zh-CN
+boarding time,登机时间,zh-CN
+boarding gate,登机口,zh-CN
+final boarding call,最后登机通知,zh-CN
+boarding group,登机组别,zh-CN
+priority boarding,优先登机,zh-CN
+missed flight,误机,zh-CN
+missed connection,错过转机航班,zh-CN
+flight delayed,航班延误,zh-CN
+flight canceled,航班取消,zh-CN
+flight disruption,航班运行中断,zh-CN
+rebook your flight,改订航班,zh-CN
+alternate flight,替代航班,zh-CN
+standby passenger,候补乘客,zh-CN
+same-day flight change,当日航班变更,zh-CN
+flight change fee,航班变更费,zh-CN
+ticket cancellation,机票取消,zh-CN
+refundable ticket,可退机票,zh-CN
+nonrefundable ticket,不可退机票,zh-CN
+travel voucher,旅行代金券,zh-CN
+airline credit,航空公司抵用金,zh-CN
+fare difference,票价差额,zh-CN
+economy class,经济舱,zh-CN
+premium economy,超级经济舱,zh-CN
+business class,商务舱,zh-CN
+first class cabin,头等舱,zh-CN
+checked baggage,托运行李,zh-CN
+carry-on baggage,随身行李,zh-CN
+personal item allowance,随身小件行李限额,zh-CN
+baggage allowance,行李限额,zh-CN
+excess baggage fee,超额行李费,zh-CN
+oversized baggage,超大行李,zh-CN
+overweight baggage,超重行李,zh-CN
+special baggage,特殊行李,zh-CN
+baggage claim,行李提取处,zh-CN
+baggage carousel,行李转盘,zh-CN
+delayed baggage,行李延误,zh-CN
+damaged baggage,行李损坏,zh-CN
+baggage service desk,行李服务柜台,zh-CN
+ground transportation,地面交通,zh-CN
+public transportation,公共交通,zh-CN
+train station,火车站,zh-CN
+railway station,铁路车站,zh-CN
+coach station,长途客运站,zh-CN
+subway station,地铁站,zh-CN
+metro station,地铁站,zh-CN
+light rail station,轻轨车站,zh-CN
+ferry terminal,渡轮码头,zh-CN
+rideshare pickup area,网约车上客区,zh-CN
+car rental counter,租车柜台,zh-CN
+rental car reservation,租车预订,zh-CN
+car rental agreement,租车协议,zh-CN
+primary driver,主要驾驶人,zh-CN
+additional driver,附加驾驶人,zh-CN
+driver's license number,驾驶证号码,zh-CN
+international driving permit,国际驾驶许可证,zh-CN
+vehicle class,车辆级别,zh-CN
+vehicle pickup location,取车地点,zh-CN
+vehicle return location,还车地点,zh-CN
+full-to-full fuel policy,满油取还政策,zh-CN
+unlimited mileage,不限里程,zh-CN
+mileage allowance,里程额度,zh-CN
+collision damage waiver,碰撞损失免责,zh-CN
+loss damage waiver,车辆损失免责,zh-CN
+roadside assistance,道路救援,zh-CN
+parking charges,停车费,zh-CN
+traffic congestion,交通拥堵,zh-CN
+service disruption,服务中断,zh-CN
+replacement bus service,替代巴士服务,zh-CN
+platform number,站台号,zh-CN
+railway track number,铁路股道号,zh-CN
+carriage number,车厢号,zh-CN
+reserved seat,预留座位,zh-CN
+quiet carriage,安静车厢,zh-CN
+peak travel hours,出行高峰时段,zh-CN
+off-peak fare,非高峰票价,zh-CN
+single-ride ticket,单次乘车票,zh-CN
+contactless payment accepted,支持非接触式支付,zh-CN
+tap in and tap out,进出站刷卡,zh-CN
+service advisory,运营提示,zh-CN
+hotel reservation,酒店预订,zh-CN
+property address,房产地址,zh-CN
+accommodation amenities,住宿设施,zh-CN
+room availability,客房供应情况,zh-CN
+average nightly rate,平均每晚房价,zh-CN
+total stay price,住宿总价,zh-CN
+destination fee,目的地附加费,zh-CN
+security deposit,押金,zh-CN
+incidental deposit,杂费押金,zh-CN
+damage deposit,损坏押金,zh-CN
+check-in date,入住日期,zh-CN
+check-out date,退房日期,zh-CN
+check-in time,入住时间,zh-CN
+check-out time,退房时间,zh-CN
+early check-in,提前入住,zh-CN
+late check-out,延迟退房,zh-CN
+reception desk,接待处,zh-CN
+concierge service,礼宾服务,zh-CN
+luggage storage,行李寄存,zh-CN
+housekeeping service,客房清洁服务,zh-CN
+daily housekeeping,每日客房清洁,zh-CN
+do not disturb,请勿打扰,zh-CN
+turndown service,夜床服务,zh-CN
+complimentary breakfast,免费早餐,zh-CN
+breakfast included,包含早餐,zh-CN
+accessible room,无障碍客房,zh-CN
+connecting rooms,相连客房,zh-CN
+adjoining rooms,相邻客房,zh-CN
+suite upgrade,套房升级,zh-CN
+crib available,可提供婴儿床,zh-CN
+maximum occupancy,最多入住人数,zh-CN
+number of guests,住客人数,zh-CN
+primary guest,主要住客,zh-CN
+additional guest,额外住客,zh-CN
+special requests,特殊要求,zh-CN
+non-smoking room,无烟客房,zh-CN
+pet-friendly property,允许携带宠物的住宿,zh-CN
+hotel cancellation policy,酒店取消政策,zh-CN
+free cancellation,免费取消,zh-CN
+nonrefundable rate,不可退款房价,zh-CN
+no-show charge,未入住费用,zh-CN
+modify your reservation,修改您的预订,zh-CN
+cancel your reservation,取消您的预订,zh-CN
+booking confirmation email,预订确认邮件,zh-CN
+work schedule,工作安排,zh-CN
+business hours,营业时间,zh-CN
+flexible working hours,弹性工作时间,zh-CN
+core working hours,核心工作时间,zh-CN
+full-time position,全职职位,zh-CN
+part-time position,兼职职位,zh-CN
+temporary position,临时职位,zh-CN
+permanent position,长期职位,zh-CN
+fixed-term contract,固定期限合同,zh-CN
+independent contractor,独立承包人,zh-CN
+contract employee,合同制员工,zh-CN
+hourly employee,时薪员工,zh-CN
+salaried employee,薪资制员工,zh-CN
+remote position,远程职位,zh-CN
+hybrid position,混合办公职位,zh-CN
+on-site position,现场办公职位,zh-CN
+job description,职位说明,zh-CN
+position summary,职位概述,zh-CN
+key responsibilities,主要职责,zh-CN
+required qualifications,必备资格,zh-CN
+preferred qualifications,优先资格,zh-CN
+minimum requirements,最低要求,zh-CN
+relevant experience,相关经验,zh-CN
+years of experience,工作年限,zh-CN
+educational background,教育背景,zh-CN
+professional certification,专业认证,zh-CN
+employment eligibility,就业资格,zh-CN
+work authorization,工作许可,zh-CN
+visa sponsorship,工作签证担保,zh-CN
+equal opportunity employer,平等机会雇主,zh-CN
+reasonable accommodation,合理便利措施,zh-CN
+annual salary,年薪,zh-CN
+starting salary,起薪,zh-CN
+salary expectations,期望薪资,zh-CN
+compensation package,薪酬方案,zh-CN
+performance bonus,绩效奖金,zh-CN
+signing bonus,签约奖金,zh-CN
+employee benefits,员工福利,zh-CN
+health insurance benefits,健康保险福利,zh-CN
+retirement benefits,退休福利,zh-CN
+paid time off (PTO),带薪休假 PTO,zh-CN
+paid sick leave,带薪病假,zh-CN
+parental leave,育儿假,zh-CN
+bereavement leave,丧亲假,zh-CN
+public holiday pay,公共假日薪酬,zh-CN
+employee discount,员工折扣,zh-CN
+professional development budget,职业发展预算,zh-CN
+tuition reimbursement,学费补助,zh-CN
+commuter benefits,通勤福利,zh-CN
+job application,求职申请,zh-CN
+application deadline,申请截止日期,zh-CN
+application status,申请状态,zh-CN
+application materials,申请材料,zh-CN
+online application form,在线申请表,zh-CN
+employment application,就业申请表,zh-CN
+curriculum vitae (CV),个人简历 CV,zh-CN
+professional résumé,职业简历,zh-CN
+writing sample,写作样本,zh-CN
+portfolio link,作品集链接,zh-CN
+professional references,职业推荐人,zh-CN
+reference check,推荐人核查,zh-CN
+background check,背景调查,zh-CN
+criminal background check,犯罪记录背景调查,zh-CN
+employment verification,工作经历核验,zh-CN
+education verification,学历核验,zh-CN
+screening questionnaire,筛选问卷,zh-CN
+phone screening interview,电话初筛面试,zh-CN
+video interview,视频面试,zh-CN
+in-person interview,现场面试,zh-CN
+panel interview,小组面试,zh-CN
+technical interview,技术面试,zh-CN
+behavioral interview,行为面试,zh-CN
+interview schedule,面试安排,zh-CN
+interview availability,可面试时间,zh-CN
+interview confirmation,面试确认,zh-CN
+interview feedback,面试反馈,zh-CN
+hiring manager,招聘经理,zh-CN
+recruiting coordinator,招聘协调员,zh-CN
+talent acquisition team,人才招聘团队,zh-CN
+conditional job offer,有条件录用通知,zh-CN
+offer expiration date,录用通知有效期,zh-CN
+accept the offer,接受录用,zh-CN
+decline the offer,拒绝录用,zh-CN
+notice period,离职通知期,zh-CN
+probationary period,试用期,zh-CN
+employment agreement,劳动合同,zh-CN
+confidentiality agreement,保密协议,zh-CN
+non-disclosure agreement (NDA),保密协议 NDA,zh-CN
+non-compete agreement,竞业禁止协议,zh-CN
+employee handbook,员工手册,zh-CN
+code of conduct,行为准则,zh-CN
+workplace policy,工作场所政策,zh-CN
+onboarding process,入职流程,zh-CN
+new hire orientation,新员工培训,zh-CN
+employee identification number,员工编号,zh-CN
+payroll information,工资发放信息,zh-CN
+direct deposit form,工资直接存款表,zh-CN
+tax withholding form,预扣税表,zh-CN
+emergency contact form,紧急联系人表,zh-CN
+performance review,绩效评估,zh-CN
+annual performance review,年度绩效评估,zh-CN
+career development plan,职业发展计划,zh-CN
+promotion opportunity,晋升机会,zh-CN
+internal job posting,内部招聘信息,zh-CN
+notice of resignation,辞职通知,zh-CN
+exit interview,离职面谈,zh-CN
+final paycheck,最后一笔工资,zh-CN
+severance pay,遣散费,zh-CN
+termination of employment,终止雇佣关系,zh-CN
+workplace meeting,工作会议,zh-CN
+meeting agenda,会议议程,zh-CN
+meeting minutes,会议纪要,zh-CN
+meeting invitation,会议邀请,zh-CN
+meeting organizer,会议组织者,zh-CN
+meeting attendees,参会人员,zh-CN
+conference room,会议室,zh-CN
+video conference link,视频会议链接,zh-CN
+dial-in number,电话接入号码,zh-CN
+calendar invitation,日历邀请,zh-CN
+accept the invitation,接受邀请,zh-CN
+decline the invitation,拒绝邀请,zh-CN
+propose a new time,建议新时间,zh-CN
+tentative response,暂定回复,zh-CN
+out of office,不在办公室,zh-CN
+out-of-office reply,外出自动回复,zh-CN
+working remotely,远程办公,zh-CN
+annual leave request,年假申请,zh-CN
+time-off request,休假申请,zh-CN
+expense report,费用报销单,zh-CN
+expense reimbursement,费用报销,zh-CN
+business travel request,商务出差申请,zh-CN
+purchase requisition,采购申请,zh-CN
+approval workflow,审批流程,zh-CN
+document approval,文件审批,zh-CN
+electronic signature,电子签名,zh-CN
+signature request,签名请求,zh-CN
+shared workspace,共享工作区,zh-CN
+shared document,共享文档,zh-CN
+view-only access,仅查看权限,zh-CN
+comment-only access,仅评论权限,zh-CN
+editing access,编辑权限,zh-CN
+request access,申请访问权限,zh-CN
+access granted,已授予访问权限,zh-CN
+access revoked,访问权限已撤销,zh-CN
+version history,版本历史记录,zh-CN
+Microsoft Word Track Changes,Microsoft Word 修订功能,zh-CN
+suggesting mode,建议模式,zh-CN
+resolve a comment,将评论标记为已解决,zh-CN
+assign a task,分配任务,zh-CN
+task deadline,任务截止日期,zh-CN
+project deadline,项目截止日期,zh-CN
+project milestone,项目里程碑,zh-CN
+project status update,项目状态更新,zh-CN
+academic year,学年,zh-CN
+enrollment period,注册入学期,zh-CN
+admissions office,招生办公室,zh-CN
+admission requirements,入学要求,zh-CN
+application fee,申请费,zh-CN
+tuition and fees,学费及杂费,zh-CN
+financial aid application,助学金申请,zh-CN
+scholarship application,奖学金申请,zh-CN
+student identification number,学号,zh-CN
+course catalog,课程目录,zh-CN
+course registration,选课注册,zh-CN
+prerequisite course,先修课程,zh-CN
+class schedule,课程表,zh-CN
+course syllabus,课程大纲,zh-CN
+learning objectives,学习目标,zh-CN
+assignment deadline,作业截止日期,zh-CN
+grading policy,评分政策,zh-CN
+academic transcript,学业成绩单,zh-CN
+enrollment verification,在读证明,zh-CN
+graduation requirements,毕业要求,zh-CN
+rental application,租房申请,zh-CN
+lease agreement,租赁协议,zh-CN
+rental security deposit,租房押金,zh-CN
+move-out date,搬出日期,zh-CN
+property manager,物业经理,zh-CN
+maintenance request,维修申请,zh-CN
+emergency maintenance,紧急维修,zh-CN
+electricity service,供电服务,zh-CN
+water service,供水服务,zh-CN
+natural gas service,天然气服务,zh-CN
+internet service provider,互联网服务提供商,zh-CN
+renter's insurance,租客保险,zh-CN
+proof of income,收入证明,zh-CN
+tenant screening,租客审查,zh-CN
+rental history,租房记录,zh-CN
+notice to vacate,搬离通知,zh-CN
+lease renewal,续租,zh-CN
+breaking news alert,突发新闻提醒,zh-CN
+live news coverage,新闻直播报道,zh-CN
+news analysis,新闻分析,zh-CN
+opinion column,观点专栏,zh-CN
+editorial board,编委会,zh-CN
+public statement,公开声明,zh-CN
+fact-checking report,事实核查报告,zh-CN
+correction notice,更正声明,zh-CN
+content warning,内容警告,zh-CN
+sensitive content,敏感内容,zh-CN
+community post,社区帖子,zh-CN
+direct message,私信,zh-CN
+private message,私人消息,zh-CN
+friend request,好友请求,zh-CN
+follow request,关注请求,zh-CN
+blocked account,已屏蔽账户,zh-CN
+muted account,已静音账户,zh-CN
+verified account,已认证账户,zh-CN
+sponsored content,赞助内容,zh-CN
+United Nations (UN),联合国 UN,zh-CN
+World Health Organization (WHO),世界卫生组织 WHO,zh-CN
+World Trade Organization (WTO),世界贸易组织 WTO,zh-CN
+World Bank Group,世界银行集团,zh-CN
+European Union (EU),欧洲联盟 EU,zh-CN
+North Atlantic Treaty Organization (NATO),北大西洋公约组织 NATO,zh-CN
+Organisation for Economic Co-operation and Development (OECD),经济合作与发展组织 OECD,zh-CN
+International Labour Organization (ILO),国际劳工组织 ILO,zh-CN
+International Civil Aviation Organization (ICAO),国际民用航空组织 ICAO,zh-CN
+International Air Transport Association (IATA),国际航空运输协会 IATA,zh-CN
+International Organization for Standardization (ISO),国际标准化组织 ISO,zh-CN
+Internal Revenue Service (IRS),美国国税局 IRS,zh-CN
+Transportation Security Administration (TSA),美国运输安全管理局 TSA,zh-CN
+Department of Motor Vehicles (DMV),机动车辆管理局 DMV,zh-CN
+Social Security Administration (SSA),美国社会保障局 SSA,zh-CN
+Centers for Disease Control and Prevention (CDC),美国疾病控制与预防中心 CDC,zh-CN
+Food and Drug Administration (FDA),美国食品药品监督管理局 FDA,zh-CN
+United States Postal Service (USPS),美国邮政署 USPS,zh-CN
+National Weather Service (NWS),美国国家气象局 NWS,zh-CN
+Federal Emergency Management Agency (FEMA),美国联邦紧急事务管理署 FEMA,zh-CN
+Consumer Financial Protection Bureau (CFPB),美国消费者金融保护局 CFPB,zh-CN

--- a/glossaries/idioms-slang-conversation_zh-CN.csv
+++ b/glossaries/idioms-slang-conversation_zh-CN.csv
@@ -1,0 +1,602 @@
+source,target,tgt_lng
+a blessing in disguise,因祸得福,zh-CN
+a dime a dozen,多得不稀奇,zh-CN
+a drop in the bucket,杯水车薪,zh-CN
+a fish out of water,格格不入的人,zh-CN
+a flash in the pan,昙花一现,zh-CN
+a grey area,灰色地带,zh-CN
+a hard pill to swallow,难以接受的事实,zh-CN
+it may be a long shot,这事成功希望渺茫,zh-CN
+the results are a mixed bag,结果有好有坏,zh-CN
+a necessary evil,不得已的坏事,zh-CN
+be a real pain in the neck,真让人头疼,zh-CN
+a piece of cake,小菜一碟,zh-CN
+feel like a slap in the face,感觉像当面羞辱,zh-CN
+a slippery slope,危险的滑坡效应,zh-CN
+a snowball effect,滚雪球效应,zh-CN
+a storm in a teacup,小题大做,zh-CN
+a taste of your own medicine,自食其果,zh-CN
+a tough act to follow,难以超越的前例,zh-CN
+add fuel to the fire,火上浇油,zh-CN
+add insult to injury,雪上加霜,zh-CN
+against all odds,排除万难,zh-CN
+all in the same boat,大家处境相同,zh-CN
+the plan is all over the place,计划杂乱无章,zh-CN
+be an open book,为人坦诚，毫无秘密,zh-CN
+as cool as a cucumber,镇定自若,zh-CN
+reach a crossroads in life,走到人生的十字路口,zh-CN
+at the drop of a hat,说做就做,zh-CN
+back against the wall,被逼入绝境,zh-CN
+back to square one,回到原点,zh-CN
+bark up the wrong tree,找错对象,zh-CN
+beat around the bush,拐弯抹角,zh-CN
+bend over backwards,竭尽全力,zh-CN
+best of both worlds,两全其美,zh-CN
+bite off more than you can chew,贪多嚼不烂,zh-CN
+bite the bullet,硬着头皮面对,zh-CN
+bite the hand that feeds you,恩将仇报,zh-CN
+blow off steam,发泄情绪,zh-CN
+break the ice,打破僵局,zh-CN
+bring home the bacon,挣钱养家,zh-CN
+burn your bridges,断绝自己的后路,zh-CN
+burn the candle at both ends,过度透支精力,zh-CN
+bury the hatchet,握手言和,zh-CN
+by the skin of your teeth,勉强过关,zh-CN
+call it a day,今天就到这里,zh-CN
+calm before the storm,暴风雨前的平静,zh-CN
+carry the weight of the world,背负沉重压力,zh-CN
+caught between a rock and a hard place,进退两难,zh-CN
+change of heart,改变心意,zh-CN
+chip on your shoulder,心怀怨气,zh-CN
+clear the air between us,消除我们之间的误会,zh-CN
+close but no cigar,差一点就成功,zh-CN
+come full circle,兜了一圈回到原点,zh-CN
+compare apples and oranges,把不能相比的事物硬作比较,zh-CN
+cost an arm and a leg,贵得离谱,zh-CN
+cross that bridge when we come to it,到时候再想办法,zh-CN
+cry over spilled milk,为无法挽回的事懊悔,zh-CN
+cut corners on quality,在质量上偷工减料,zh-CN
+cut to the chase,直奔主题,zh-CN
+devil is in the details,魔鬼藏在细节中,zh-CN
+dig your own grave,自掘坟墓,zh-CN
+don't count your chickens before they hatch,别高兴得太早,zh-CN
+don't put all your eggs in one basket,不要孤注一掷,zh-CN
+be a down-to-earth person,为人脚踏实地,zh-CN
+draw a blank,脑中一片空白,zh-CN
+easier said than done,说来容易做来难,zh-CN
+every cloud has a silver lining,祸中有福,zh-CN
+face the music,承担后果,zh-CN
+fair and square,光明正大,zh-CN
+feel under the weather,身体有些不舒服,zh-CN
+find your feet in a new place,逐渐适应新环境,zh-CN
+fly by the seat of your pants,凭感觉临场应付,zh-CN
+get cold feet,临阵退缩,zh-CN
+get out of hand,变得失控,zh-CN
+get the ball rolling,把事情启动起来,zh-CN
+get the hang of it,掌握诀窍,zh-CN
+go back to the drawing board,推倒重来,zh-CN
+see the plan go down in flames,眼看计划惨败收场,zh-CN
+go the extra mile,多付出一份努力,zh-CN
+go with the flow,顺其自然,zh-CN
+have your future hanging by a thread,前途岌岌可危,zh-CN
+have a bone to pick,有件事要理论,zh-CN
+have bigger fish to fry,有更重要的事要做,zh-CN
+have your hands full,忙得不可开交,zh-CN
+hear it through the grapevine,从小道消息听说,zh-CN
+hit below the belt,使阴招,zh-CN
+hit the ground running,一上来就全力投入,zh-CN
+hit the nail on the head,一针见血,zh-CN
+hold your horses,先别急,zh-CN
+in a nutshell,简而言之,zh-CN
+in over your head,超出能力范围,zh-CN
+in the long run,从长远来看,zh-CN
+in the same boat,处境相同,zh-CN
+it takes two to tango,一个巴掌拍不响,zh-CN
+jump on the bandwagon,跟风,zh-CN
+jump the gun,操之过急,zh-CN
+keep an eye on the situation,留意事态发展,zh-CN
+keep your chin up,振作起来,zh-CN
+kill two birds with one stone,一举两得,zh-CN
+know the ropes,熟悉门道,zh-CN
+leave no stone unturned,想尽一切办法,zh-CN
+let sleeping dogs lie,别自找麻烦,zh-CN
+let the cat out of the bag,说漏了秘密,zh-CN
+level playing field,公平的竞争环境,zh-CN
+light at the end of the tunnel,困境尽头的希望,zh-CN
+like finding a needle in a haystack,如同大海捞针,zh-CN
+live and learn,活到老学到老,zh-CN
+make a long story short,长话短说,zh-CN
+miss the boat on an opportunity,错失一个机会,zh-CN
+no strings attached,不附带任何条件,zh-CN
+not out of the woods,尚未脱离困境,zh-CN
+off the beaten path,远离常规路线,zh-CN
+once in a blue moon,难得一次,zh-CN
+on the fence,犹豫不决,zh-CN
+make sure we're on the same page,确保我们意见一致,zh-CN
+open a can of worms,惹出一堆麻烦,zh-CN
+out of the blue,出乎意料地,zh-CN
+out of your depth,力所不及,zh-CN
+we'll play it by ear,到时候看情况再决定,zh-CN
+put your foot in your mouth,说错话得罪人,zh-CN
+read between the lines,读懂言外之意,zh-CN
+risk rocking the boat,冒着打破现状的风险,zh-CN
+rub salt in the wound,在伤口上撒盐,zh-CN
+rule of thumb,经验法则,zh-CN
+save for a rainy day,未雨绸缪,zh-CN
+see eye to eye,看法一致,zh-CN
+speak of the devil,说曹操曹操到,zh-CN
+spill the beans,说出秘密,zh-CN
+take it with a grain of salt,对此不要全信,zh-CN
+take the bull by the horns,迎难而上,zh-CN
+the ball is in your court,该你做决定了,zh-CN
+the best thing since sliced bread,好得不得了的新事物,zh-CN
+the elephant in the room,明摆着却无人提及的问题,zh-CN
+the last straw,压垮骆驼的最后一根稻草,zh-CN
+the tip of the iceberg,冰山一角,zh-CN
+throw caution to the wind,不顾风险放手去做,zh-CN
+throw in the towel,认输,zh-CN
+turn a blind eye,视而不见,zh-CN
+the decision is still up in the air,决定仍未确定,zh-CN
+walk on eggshells,小心翼翼,zh-CN
+water under the bridge,过去的事就让它过去,zh-CN
+wear your heart on your sleeve,喜怒形于色,zh-CN
+when pigs fly,绝不可能,zh-CN
+the whole nine yards,全部都包括在内,zh-CN
+a wild goose chase,徒劳无功的寻找,zh-CN
+your guess is as good as mine,我也不知道,zh-CN
+at face value,按表面意思,zh-CN
+behind closed doors,在幕后秘密进行,zh-CN
+below the surface,隐藏在表面之下,zh-CN
+beyond the pale,超出可接受范围,zh-CN
+by word of mouth,通过口口相传,zh-CN
+come rain or shine,无论晴雨,zh-CN
+down the rabbit hole,越陷越深地探索,zh-CN
+in broad daylight,光天化日之下,zh-CN
+in hot water,陷入麻烦,zh-CN
+in the heat of the moment,一时冲动之下,zh-CN
+in the nick of time,在最后关头,zh-CN
+in plain sight,就在眼皮底下,zh-CN
+the project is in the pipeline,项目正在筹备中,zh-CN
+in your best interest,符合你的最大利益,zh-CN
+make ends meet,维持收支平衡,zh-CN
+move the goalposts,临时改变规则,zh-CN
+off the top of my head,凭我当下的印象,zh-CN
+on borrowed time,时日无多,zh-CN
+you're on thin ice,你的处境很危险,zh-CN
+pull the plug on a project,叫停一个项目,zh-CN
+raise the bar,提高标准,zh-CN
+read the mood in the room,看懂现场气氛,zh-CN
+set the record straight,澄清事实,zh-CN
+take the edge off the pain,稍微缓解疼痛,zh-CN
+the writing on the wall,不祥之兆已经显现,zh-CN
+through thick and thin,同甘共苦,zh-CN
+toe the line,遵守规矩,zh-CN
+turn the tables,扭转局势,zh-CN
+up the ante,加大赌注,zh-CN
+weather the crisis,渡过危机,zh-CN
+work against the clock,争分夺秒,zh-CN
+worth your while,值得花时间,zh-CN
+no big deal,没什么大不了,zh-CN
+no hard feelings,别放在心上,zh-CN
+not a chance,不可能,zh-CN
+not my thing,不是我的菜,zh-CN
+not worth it,不值得,zh-CN
+not so fast,先别急,zh-CN
+no way around it,没有别的办法,zh-CN
+no need to rush,不用着急,zh-CN
+no rush at all,一点也不急,zh-CN
+no harm done,没造成什么损失,zh-CN
+I'm genuinely happy for you,我真替你高兴,zh-CN
+good to know,了解了,zh-CN
+suit yourself,随你便,zh-CN
+be my guest,请便,zh-CN
+help yourself,请自便,zh-CN
+make yourself at home,别拘束,zh-CN
+take your time,慢慢来,zh-CN
+take good care,多保重,zh-CN
+hang in there,坚持住,zh-CN
+keep me posted,随时告诉我进展,zh-CN
+keep in touch,保持联系,zh-CN
+stay in touch,保持联系,zh-CN
+let me know,告诉我一声,zh-CN
+give me a heads-up,提前提醒我一下,zh-CN
+thanks for the heads-up,谢谢你提前提醒,zh-CN
+thanks anyway,还是谢谢你,zh-CN
+much appreciated,非常感谢,zh-CN
+I owe you one,我欠你一个人情,zh-CN
+don't mention it,不用客气,zh-CN
+same to you,你也一样,zh-CN
+go for it,大胆去做吧,zh-CN
+go right ahead,尽管去做,zh-CN
+feel free to ask,有问题尽管问,zh-CN
+what do you mean,你是什么意思,zh-CN
+what are you getting at,你到底想说什么,zh-CN
+so far so good,到目前为止一切顺利,zh-CN
+so much for that,这下算是泡汤了,zh-CN
+believe it or not,信不信由你,zh-CN
+if you say so,你说是就是吧,zh-CN
+you can say that again,说得太对了,zh-CN
+now you're talking,这才像话,zh-CN
+that's more like it,这才对嘛,zh-CN
+that's not the point,重点不在这里,zh-CN
+that's beside the point,这与重点无关,zh-CN
+that's the spirit,这才对嘛,zh-CN
+it's up to you,由你决定,zh-CN
+it's your call,由你决定,zh-CN
+you make the call,你来决定,zh-CN
+I mean it,我是认真的,zh-CN
+I take it back,我收回刚才的话,zh-CN
+I stand corrected,我承认是我错了,zh-CN
+I beg to differ,恕我不能同意,zh-CN
+I couldn't agree more,我完全同意,zh-CN
+I wouldn't count on it,我劝你别指望,zh-CN
+I can live with that,这样我能接受,zh-CN
+I can work with that,这样我可以配合,zh-CN
+I don't mind,我不介意,zh-CN
+I don't blame you,我能理解你,zh-CN
+I can't help laughing,我忍不住笑,zh-CN
+I can't make it to the meeting,我参加不了会议,zh-CN
+I can't put my finger on it,我说不清问题在哪,zh-CN
+I have no idea,我完全不知道,zh-CN
+I have a feeling,我有一种预感,zh-CN
+I'm having second thoughts,我开始犹豫了,zh-CN
+I lost track of time,我忘了时间,zh-CN
+I spoke too soon,我话说早了,zh-CN
+it doesn't matter,没关系,zh-CN
+it makes sense,这说得通,zh-CN
+it rings a bell,听起来有点耳熟,zh-CN
+it slipped my mind,我一时忘了,zh-CN
+it takes time,这需要时间,zh-CN
+it was worth a try,值得一试,zh-CN
+it never hurts to ask,问问总没坏处,zh-CN
+it's about time,早就该这样了,zh-CN
+it's a long story,说来话长,zh-CN
+it's no use,没有用,zh-CN
+it's not the end of the world,天还没塌下来,zh-CN
+it's easier that way,那样更省事,zh-CN
+it's nothing personal,这不是针对你,zh-CN
+it's none of my business,这不关我的事,zh-CN
+it's not up to me,这不由我决定,zh-CN
+it's not what it looks like,事情不是你看到的那样,zh-CN
+it's too good to be true,好得令人难以置信,zh-CN
+it's your loss,吃亏的是你,zh-CN
+mind your own business,少管闲事,zh-CN
+don't take it personally,别往心里去,zh-CN
+don't get me wrong,别误会我的意思,zh-CN
+don't jump to conclusions,别急着下结论,zh-CN
+don't take this the wrong way,别误会我接下来的话,zh-CN
+don't worry about it,别担心这事,zh-CN
+don't let it get to you,别让这事影响你,zh-CN
+don't beat yourself up,别太自责,zh-CN
+don't sell yourself short,别低估自己,zh-CN
+don't get your hopes up,别抱太高期望,zh-CN
+don't be so hard on yourself,别对自己太苛刻,zh-CN
+to be honest,说实话,zh-CN
+to be fair,公平地说,zh-CN
+to be clear,说清楚一点,zh-CN
+to be precise,准确地说,zh-CN
+for what it's worth,不管有没有用，我还是想说,zh-CN
+as far as I know,据我所知,zh-CN
+as far as I'm concerned,在我看来,zh-CN
+if I remember correctly,如果我没记错,zh-CN
+if I'm not mistaken,如果我没有弄错,zh-CN
+come to think of it,仔细想想,zh-CN
+speaking of which,说到这个,zh-CN
+for the time being,暂时,zh-CN
+once and for all,彻底地,zh-CN
+by any chance,不知是否,zh-CN
+by the way,顺便说一下,zh-CN
+in any case,无论如何,zh-CN
+in that case,既然如此,zh-CN
+at any rate,不管怎样,zh-CN
+at the very least,至少,zh-CN
+in no time,很快,zh-CN
+at the same time,与此同时,zh-CN
+sooner or later,迟早,zh-CN
+more or less,或多或少,zh-CN
+little by little,一点一点地,zh-CN
+day by day,一天天地,zh-CN
+everything happened all at once,所有事情同时发生,zh-CN
+every now and then,偶尔,zh-CN
+from time to time,不时,zh-CN
+one way or another,无论如何,zh-CN
+go viral online,在网上爆红,zh-CN
+break the internet,引爆全网,zh-CN
+blow up on social media,在社交媒体上突然爆火,zh-CN
+trend on social media,登上社交媒体热榜,zh-CN
+gain online traction,在网上逐渐获得关注,zh-CN
+get ratioed online,在网上被反对回复压过点赞,zh-CN
+doomscroll through the feed,不停刷负面信息,zh-CN
+scroll past the post,划过这条帖子,zh-CN
+show up on my feed,出现在我的信息流里,zh-CN
+all over my feed,刷屏了我的信息流,zh-CN
+live rent-free in my head,一直萦绕在我脑海里,zh-CN
+main character energy,主角气场,zh-CN
+such a big mood,太能代表我的心情了,zh-CN
+bring the same energy,拿出同样的态度来,zh-CN
+not the right vibe,感觉不太对,zh-CN
+pass the vibe check,氛围感过关,zh-CN
+fail the vibe check,氛围感不过关,zh-CN
+log off for a while,暂时下线一会儿,zh-CN
+caught in 4K,被高清实锤,zh-CN
+receipts or it didn't happen,拿出证据，否则不算,zh-CN
+taken out of context,被断章取义,zh-CN
+context really matters,语境很重要,zh-CN
+here's my hot take,说个可能有争议的看法,zh-CN
+unpopular opinion ahead,下面是个不受欢迎的观点,zh-CN
+low-key obsessed with it,暗暗迷上了这个,zh-CN
+high-key worried about it,真的很担心这件事,zh-CN
+living my best life,过着最自在的生活,zh-CN
+chronically online behavior,典型的长期泡网行为,zh-CN
+an online pile-on,网上群起围攻,zh-CN
+get called out online,在网上被公开批评,zh-CN
+get canceled online,在网上遭到集体抵制,zh-CN
+social media backlash,社交媒体上的强烈反弹,zh-CN
+post a public apology,发布公开道歉,zh-CN
+make an apology video,制作道歉视频,zh-CN
+post a thirst trap,发布吸睛性感内容,zh-CN
+make a humble brag,假装谦虚地炫耀,zh-CN
+just a shameless plug,顺便厚着脸皮打个广告,zh-CN
+post rage bait,发布引战内容,zh-CN
+write a clickbait headline,写一个标题党标题,zh-CN
+use engagement bait,使用互动诱饵,zh-CN
+content made for the algorithm,迎合算法制作的内容,zh-CN
+try to beat the algorithm,试图突破算法限制,zh-CN
+try to game the algorithm,试图钻算法空子,zh-CN
+get shadow-banned,被暗中限流,zh-CN
+mute the whole thread,将整个讨论串静音,zh-CN
+repost with a comment,附加评论后转发,zh-CN
+share it to your story,分享到你的限时动态,zh-CN
+use a burner account,使用匿名小号,zh-CN
+run a parody account,运营戏仿账号,zh-CN
+run a fan account,运营粉丝账号,zh-CN
+be a keyboard warrior,当键盘侠,zh-CN
+feed an internet troll,回应并助长网络喷子,zh-CN
+look like a bot account,看起来像机器人账号,zh-CN
+check the comment section,看看评论区,zh-CN
+turn off the comments,关闭评论,zh-CN
+pin this comment,置顶这条评论,zh-CN
+delete the post,删除帖子,zh-CN
+archive the post,存档帖子,zh-CN
+edit the caption,编辑配文,zh-CN
+add alternative text,添加替代文字,zh-CN
+write an image description,撰写图片说明,zh-CN
+check the link in my bio,查看我个人简介里的链接,zh-CN
+send me a direct message,给我发私信,zh-CN
+follow for more,关注以查看更多内容,zh-CN
+go live on social media,在社交媒体上开直播,zh-CN
+join the livestream,加入直播,zh-CN
+react in the live chat,在直播聊天中互动,zh-CN
+make a reaction video,制作反应视频,zh-CN
+duet with the video,与该视频合拍,zh-CN
+stitch part of the video,拼接该视频片段进行回应,zh-CN
+use the trending audio,使用热门音频,zh-CN
+use a viral sound,使用爆火音效,zh-CN
+reuse the meme format,套用这个梗图模板,zh-CN
+post a reaction meme,发布反应梗图,zh-CN
+share an inside joke,分享圈内笑话,zh-CN
+start fandom discourse,引发粉丝圈争论,zh-CN
+it's a canon event,这是注定要经历的关键事件,zh-CN
+post a fan theory,发布粉丝猜想,zh-CN
+write a spoiler-free review,写一篇无剧透评论,zh-CN
+have a spoiler-heavy discussion,进行大量剧透的讨论,zh-CN
+binge-watch the whole series,一口气刷完整部剧,zh-CN
+hate-watch the show,边嫌弃边追这部剧,zh-CN
+rewatch a comfort show,重看一部治愈自己的剧,zh-CN
+call it a guilty pleasure,称它为有点羞于承认的爱好,zh-CN
+add it to the must-watch list,把它加入必看清单,zh-CN
+host a watch party,组织集体观影,zh-CN
+no one asked for this,根本没人要求这个,zh-CN
+thanks for coming to my TED Talk,谢谢听完我的长篇大论,zh-CN
+this did not age well,这现在看来很经不起时间考验,zh-CN
+aged like fine wine,历久弥新,zh-CN
+aged like milk,很快就变得不合时宜,zh-CN
+say it louder for the people in the back,说大声点，让后面的人也听见,zh-CN
+make it make sense,谁来把这解释清楚,zh-CN
+understood the assignment,完全领会并完成了要求,zh-CN
+woke up and chose violence,一醒来就选择火力全开,zh-CN
+circle back on this,之后再回头讨论这件事,zh-CN
+keep me in the loop,让我随时了解进展,zh-CN
+move the needle on the outcome,对结果产生实质影响,zh-CN
+think outside the box,跳出框架思考,zh-CN
+focus on the low-hanging fruit,先处理最容易见效的部分,zh-CN
+have the bandwidth for it,有精力和时间处理它,zh-CN
+put it on my radar,让我注意到这件事,zh-CN
+keep it on your radar,持续留意这件事,zh-CN
+run it up the flagpole,把方案报上去试探反应,zh-CN
+try to boil the ocean,试图一次解决所有问题,zh-CN
+do a deep dive into it,深入研究这件事,zh-CN
+drill down into the details,深入查看细节,zh-CN
+align on the next steps,就后续步骤达成一致,zh-CN
+get everyone aligned,让大家形成共识,zh-CN
+own the final outcome,为最终结果负责,zh-CN
+step up to the plate,挺身承担责任,zh-CN
+wear many different hats,身兼多职,zh-CN
+flag this for review,标记此项以供审查,zh-CN
+push back on the proposal,对该提议提出异议,zh-CN
+back me up on this,在这件事上支持我,zh-CN
+get buy-in from the team,获得团队认同,zh-CN
+secure stakeholder buy-in,获得利益相关方支持,zh-CN
+manage everyone's expectations,管理各方预期,zh-CN
+set clear expectations,设定清晰预期,zh-CN
+reset the expectations,重新调整预期,zh-CN
+find some common ground,找到共同点,zh-CN
+make a judgment call,根据判断作出决定,zh-CN
+go with your gut,相信自己的直觉,zh-CN
+play devil's advocate,故意提出反方观点,zh-CN
+keep it high-level,只谈总体层面,zh-CN
+get too far into the weeds,陷入过多细节,zh-CN
+cut through all the distractions,排除干扰抓住重点,zh-CN
+from a high-level perspective,从总体层面看,zh-CN
+look at the big picture,着眼大局,zh-CN
+the project has many moving parts,项目有许多相互关联的环节,zh-CN
+single point of contact,单一联络人,zh-CN
+hand the work off,把工作交接出去,zh-CN
+take the lead on this,牵头处理这件事,zh-CN
+pick up a teammate's slack,补上同事落下的工作,zh-CN
+share the workload,分担工作量,zh-CN
+pull your own weight,尽好自己的职责,zh-CN
+drop everything else,先放下其他所有事情,zh-CN
+deal with competing priorities,处理相互冲突的优先事项,zh-CN
+handle a time-sensitive request,处理时效性很强的请求,zh-CN
+work toward a hard deadline,赶一个不能延期的截止时间,zh-CN
+set a soft deadline,设定一个可调整的截止时间,zh-CN
+we're in crunch time,现在到了冲刺阶段,zh-CN
+finish under the wire,赶在最后一刻完成,zh-CN
+finish ahead of schedule,提前完成,zh-CN
+fall behind schedule,落后于计划,zh-CN
+get back on track,回到正轨,zh-CN
+stay on track,保持按计划推进,zh-CN
+go off track,偏离正轨,zh-CN
+push back the deadline,推迟截止时间,zh-CN
+move up the deadline,提前截止时间,zh-CN
+meet the deadline,按期完成,zh-CN
+miss the deadline,错过截止时间,zh-CN
+buy the team more time,为团队争取更多时间,zh-CN
+make up for lost time,弥补耽误的时间,zh-CN
+get up to speed,快速了解情况,zh-CN
+bring you up to speed,让你快速了解最新情况,zh-CN
+deliver a quick win,迅速取得一个小成果,zh-CN
+make a long-term play,作长远布局,zh-CN
+use a short-term fix,采用短期修补方案,zh-CN
+find a permanent solution,找到永久解决方案,zh-CN
+use a stopgap measure,采取临时应急措施,zh-CN
+choose the next best action,选择下一步最佳行动,zh-CN
+agree on a plan of action,商定行动计划,zh-CN
+decide on a course of action,决定采取什么行动,zh-CN
+take this work forward,继续推进这项工作,zh-CN
+move the project forward,推动项目向前发展,zh-CN
+drive the initiative forward,推动这项举措,zh-CN
+revisit this later,稍后再重新讨论,zh-CN
+park this for now,暂时把这件事放一放,zh-CN
+hold off for now,暂时先不要做,zh-CN
+put the project on hold,暂停这个项目,zh-CN
+unblock the whole team,为整个团队扫清障碍,zh-CN
+clear the main blocker,清除主要阻碍,zh-CN
+address the underlying issue,处理根本问题,zh-CN
+find the root cause,找出根本原因,zh-CN
+play the blame game,互相推卸责任,zh-CN
+pass the buck,推卸责任,zh-CN
+cover all your bases,把各方面都考虑周全,zh-CN
+cover a colleague's shift,替同事顶班,zh-CN
+keep the discussion professional,让讨论保持专业,zh-CN
+agree to disagree,保留分歧,zh-CN
+give constructive feedback,提供建设性反馈,zh-CN
+give candid feedback,坦率地提出反馈,zh-CN
+take the feedback on board,认真听取并考虑反馈,zh-CN
+your point is taken,你的意见我接受了,zh-CN
+consider it duly noted,我已经正式记下了,zh-CN
+make the feedback actionable,让反馈可以落实,zh-CN
+deliver on your promise,兑现承诺,zh-CN
+overpromise and underdeliver,承诺过多却交付不足,zh-CN
+underpromise and overdeliver,少承诺而多交付,zh-CN
+go above and beyond,做到远超预期,zh-CN
+business as usual,一切照常,zh-CN
+all hands on deck,所有人都来帮忙,zh-CN
+learn on the job,在工作中边做边学,zh-CN
+face a steep learning curve,上手难度很高,zh-CN
+leave room for improvement,仍有改进空间,zh-CN
+good enough for now,目前这样就够用了,zh-CN
+done is better than perfect,完成比完美更重要,zh-CN
+the software is ready to ship,软件已可发布,zh-CN
+set the go-live date,确定正式上线日期,zh-CN
+hold a postmortem meeting,召开事后复盘会议,zh-CN
+you have my word,我向你保证,zh-CN
+mark my words,记住我的话,zh-CN
+you can count on me,你可以依靠我,zh-CN
+count me in,算我一个,zh-CN
+count me out,别算上我,zh-CN
+we have a deal,我们说定了,zh-CN
+it's a deal,一言为定,zh-CN
+leave it to me,交给我吧,zh-CN
+leave me out of this,别把我牵扯进来,zh-CN
+stay out of this,别插手这件事,zh-CN
+stay out of my way,别挡我的路,zh-CN
+get out of my way,给我让开,zh-CN
+don't say a word,一个字也别说,zh-CN
+enough is enough,够了，不能再这样下去了,zh-CN
+I've had enough,我已经受够了,zh-CN
+this ends now,这件事到此为止,zh-CN
+we're done here,我们到此为止,zh-CN
+end of story,事情就这么定了,zh-CN
+consider it done,就当已经办妥,zh-CN
+consider it handled,就当已经处理好了,zh-CN
+consider yourself warned,就当我警告过你了,zh-CN
+you've been warned,我已经警告过你了,zh-CN
+don't say I didn't warn you,别说我没警告过你,zh-CN
+you made your choice,这是你自己的选择,zh-CN
+make your choice,作出选择吧,zh-CN
+choose wisely,谨慎选择,zh-CN
+think this through,把这件事想清楚,zh-CN
+look me in the eye,看着我的眼睛,zh-CN
+hear me out,听我把话说完,zh-CN
+let me explain,让我解释,zh-CN
+let me finish,让我说完,zh-CN
+wait a second,等一下,zh-CN
+not another step,不许再往前一步,zh-CN
+hands where I can see them,把手放在我看得见的地方,zh-CN
+put your hands up,把手举起来,zh-CN
+drop the weapon,放下武器,zh-CN
+stay where you are,待在原地,zh-CN
+don't give up on me,别放弃我,zh-CN
+leave me alone,让我一个人待着,zh-CN
+get away from me,离我远点,zh-CN
+back away slowly,慢慢后退,zh-CN
+run for your life,快逃命,zh-CN
+save yourself,你快逃吧,zh-CN
+get to safety,快到安全的地方去,zh-CN
+take cover now,马上找掩护,zh-CN
+we're surrounded,我们被包围了,zh-CN
+we're trapped,我们被困住了,zh-CN
+there's no way out,这里没有出路,zh-CN
+follow my lead,照我做,zh-CN
+stay close to me,跟紧我,zh-CN
+stick together,大家别分开,zh-CN
+I've got your back,我挺你,zh-CN
+trust me on this,这件事相信我,zh-CN
+don't trust anyone,不要相信任何人,zh-CN
+don't believe a word,一个字也别信,zh-CN
+give me your word,向我保证,zh-CN
+swear to me,对我发誓,zh-CN
+tell me the truth,告诉我真相,zh-CN
+spare me the details,细节就不必说了,zh-CN
+don't waste your breath,别白费口舌,zh-CN
+stop putting on an act,别装了,zh-CN
+quit pretending,别再装了,zh-CN
+who are you really,你到底是谁,zh-CN
+what do you want from me,你到底想从我这里得到什么,zh-CN
+what are you hiding,你在隐瞒什么,zh-CN
+how did you know,你怎么知道的,zh-CN
+who told you,是谁告诉你的,zh-CN
+keep your voice down,小点声,zh-CN
+watch your tone,注意你的语气,zh-CN
+mind your language,说话注意点,zh-CN
+careful what you wish for,小心愿望成真,zh-CN
+don't tempt fate,别拿命运开玩笑,zh-CN
+is that a threat,这是在威胁我吗,zh-CN
+you'll regret this,你会后悔的,zh-CN
+this isn't over,这事还没完,zh-CN
+we meet again,我们又见面了,zh-CN
+long time no see,好久不见,zh-CN
+fancy meeting you here,没想到会在这里碰见你,zh-CN
+what are the odds of running into you here,怎么会这么巧,zh-CN
+it's been a while,有一阵子没见了,zh-CN
+I thought you were dead,我以为你死了,zh-CN
+glad you could make it,很高兴你能来,zh-CN
+right on time,来得正准时,zh-CN
+I was beginning to worry,我都开始担心了,zh-CN
+I knew you'd come,我就知道你会来,zh-CN
+we don't have much time,我们时间不多了,zh-CN
+time is running out,时间快用完了,zh-CN
+every second counts,每一秒都很重要,zh-CN
+we need to move now,我们得马上行动,zh-CN
+let's get out of here,我们离开这里吧,zh-CN
+let's finish this fight,我们把这一战做个了结,zh-CN
+let's make this quick,我们速战速决,zh-CN
+no turning back,已经没有回头路了,zh-CN
+there's no going back,再也回不去了,zh-CN
+it's now or never,机不可失,zh-CN
+this is our only chance,这是我们唯一的机会,zh-CN
+we have no choice,我们别无选择,zh-CN
+I need answers,我需要答案,zh-CN
+you deserve the truth,你有权知道真相,zh-CN

--- a/meta/common-everyday.json
+++ b/meta/common-everyday.json
@@ -1,0 +1,20 @@
+{
+  "id": "common-everyday",
+  "name": "Common and Everyday Language",
+  "description": "A curated English-to-Simplified-Chinese glossary for common web and everyday language, covering accounts, privacy, shopping, payments, travel, work, education, housing, news, social platforms, and public organizations.",
+  "author": "youheng-alan-liu",
+  "glossary": "common-everyday",
+  "langs": [
+    "zh-CN"
+  ],
+  "i18ns": {
+    "zh-CN": {
+      "name": "通用与日常用语",
+      "description": "常见网页与日常英语术语库，涵盖账户、隐私、购物、支付、旅行、职场、教育、住房、新闻、社交平台和公共机构。"
+    },
+    "en": {
+      "name": "Common and Everyday Language",
+      "description": "A glossary for common web and everyday language, including accounts, privacy, shopping, payments, travel, work, education, housing, news, social platforms, and public organizations."
+    }
+  }
+}

--- a/meta/idioms-slang-conversation.json
+++ b/meta/idioms-slang-conversation.json
@@ -1,0 +1,20 @@
+{
+  "id": "idioms-slang-conversation",
+  "name": "Idioms, Slang, and Conversation",
+  "description": "A curated English-to-Simplified-Chinese glossary for context-stable idioms, slang, and conversational expressions, with ambiguous fragments and punctuation-dependent utterances excluded to reduce false matches.",
+  "author": "youheng-alan-liu",
+  "glossary": "idioms-slang-conversation",
+  "langs": [
+    "zh-CN"
+  ],
+  "i18ns": {
+    "zh-CN": {
+      "name": "俗语、俚语与口语",
+      "description": "英语俗语、俚语与口语表达术语库；已排除高歧义片段和依赖标点上下文的句子，以减少误匹配。"
+    },
+    "en": {
+      "name": "Idioms, Slang, and Conversation",
+      "description": "A glossary for context-stable English idioms, slang, and conversational expressions, curated to reduce ambiguous matches."
+    }
+  }
+}

--- a/meta/index.json
+++ b/meta/index.json
@@ -1,5 +1,7 @@
 [
     "default",
+    "common-everyday",
+    "idioms-slang-conversation",
     "twitter",
     "web3",
     "tech",


### PR DESCRIPTION
## Summary

This contribution adds two English-to-Simplified-Chinese glossaries:

- `common-everyday`: 796 context-stable phrases for common web interfaces, accounts, privacy, shopping, payments, travel, work, education, housing, news, social platforms, and public organizations.
- `idioms-slang-conversation`: 601 curated idioms, slang expressions, and conversational phrases.

## Curation policy

Both glossaries favor precise opt-in matches over raw size. The common glossary excludes short ambiguous phrases and preserves source abbreviations such as FAQ, VAT, NDA, and organization initials without adding parenthetical output. The idioms/slang glossary excludes incomplete templates, lexicographic `phrase (ACRONYM)` forms, punctuation-dependent utterances, literal/idiomatic ambiguities, non-slang abbreviations, and translations that overcommit to one context. A final independent semantic review removed three additional ambiguous entries and corrected sixteen targets across the two files.

No `matches` restriction is included because the retained phrases occur across general web content rather than a truthful fixed set of domains.

## Provenance

- Authored as AI-assisted glossaries, then manually and programmatically curated for this contribution.
- No textbook index, commercial glossary, proprietary term list, or upstream row was copied.
- Every retained public row remains traceable to its contributor-provided source glossary.

## Validation

- UTF-8 without BOM and RFC 4180 CSV.
- Exact `source,target,tgt_lng` header and `zh-CN` locale in every row.
- No empty fields, duplicate sources, identity mappings, upstream overlaps, internal near-duplicate groups, placeholders, OCR fragments, or source-restating targets.
- No private paths, credentials, API keys, generated hashes, or unsupported provenance claims.
